### PR TITLE
CMake alternative math library detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [1.6.0-rc5] - 2026-04-20
+## [Unreleased]
 
 Upcoming feature release, introducing a proper C++ API for the first time, and bringing various other improvements.
 
@@ -60,6 +60,8 @@ Upcoming feature release, introducing a proper C++ API for the first time, and b
    
  - #306: `geo_posvel()` changed to return an error (-1) if used for a geodetic observer and debug mode is set to
    `NOVAS_DEBUG_EXTRA`, to warn that polar offsets are not included in the calculation. 
+
+ - #310: Change how CMake detects the need for linking against	`libm`.
 
  - Use more precise matrix from Liu et al. (2011) for equatorial / galactic conversions.
  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,9 +28,11 @@ project(supernovas
 )
 
 # Include required modules
+include(CheckLibraryExists)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 include(FeatureSummary)
+
 
 # Build options
 option(BUILD_SHARED_LIBS "Build as shared libraries instead of static" OFF)
@@ -87,10 +89,8 @@ if(WIN32)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 endif()
 
-if(WIN32)
-    set(MATHLIB "")
-else()
-    find_library(MATH_LIBRARY m REQUIRED)
+check_library_exists(m exp "" HAS_MATHLIB)
+if(HAS_MATHLIB)
     set(MATHLIB m)
     
     # [.pc] Link applications against math lib...

--- a/examples/c99/CMakeLists.txt
+++ b/examples/c99/CMakeLists.txt
@@ -18,15 +18,14 @@ if(NOT PROJECT_NAME)
         LANGUAGES C
     )
     
+    include(CheckLibraryExists)
     include(GNUInstallDirs)
         
     find_package(supernovas)
 
-    if(WIN32)
-        set(MATH "")
-    else()
-        find_library(MATH_LIBRARY m REQUIRED)
-        set(MATH m)
+    check_library_exists(m exp "" HAS_MATHLIB)
+    if(HAS_MATHLIB)
+        set(MATHLIB m)
     endif()
 endif()
 

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -18,15 +18,14 @@ if(NOT PROJECT_NAME)
         LANGUAGES CXX
     )
     
+    include(CheckLibraryExists)
     include(GNUInstallDirs)
         
     find_package(supernovas)
 
-    if(WIN32)
-        set(MATH "")
-    else()
-        find_library(MATH_LIBRARY m REQUIRED)
-        set(MATH m)
+    check_library_exists(m exp "" HAS_MATHLIB)
+    if(HAS_MATHLIB)
+        set(MATHLIB m)
     endif()
 endif()
 

--- a/include/novas.h
+++ b/include/novas.h
@@ -3436,7 +3436,7 @@ int novas_sys_to_icrs(enum novas_reference_system sys, const double *in, double 
 #define NAIF_EMB        3
 
 /// NAIF ID for the barycenter of the Pluto system
-#define NAIF_PLUTO_BARYCENTER   9
+#define NAIF_PLUTO_BARYCENTER     9
 
 
 /**
@@ -3447,24 +3447,24 @@ int novas_sys_to_icrs(enum novas_reference_system sys, const double *in, double 
 #define NOVAS_DEFAULT_MAX_ITER    100
 
 // On some older platform NAN may not be defined, so define it here if need be
-#  ifndef NAN
-#    define NAN               (0.0/0.0)
-#  endif
+#ifndef NAN
+#  define NAN                     (0.0/0.0)     ///< Define NAN (if not in `math.h`)
+#endif
 
 
-#  ifndef THREAD_LOCAL
-#    if __STDC_VERSION__ >= 202311L
-#      define THREAD_LOCAL thread_local           ///< C23 standard for thread-local variables
-#    elif __STDC_VERSION__ >= 201112L
-#      define THREAD_LOCAL _Thread_local          ///< C11 standard for thread-local variables
-#    elif __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 3)
-#      define THREAD_LOCAL __thread               ///< pre C11 gcc >= 3.3 standard for thread-local variables
-#    elif defined _MSVC_VER
-#      define THREAD_LOCAL __declspec( thread )   ///< Microsoft Visual C thread local declaration
-#    else
-#      define THREAD_LOCAL                        ///< no thread-local variables
-#    endif
+#ifndef THREAD_LOCAL
+#  if __STDC_VERSION__ >= 202311L
+#    define THREAD_LOCAL thread_local           ///< C23 standard for thread-local variables
+#  elif __STDC_VERSION__ >= 201112L
+#    define THREAD_LOCAL _Thread_local          ///< C11 standard for thread-local variables
+#  elif __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 3)
+#    define THREAD_LOCAL __thread               ///< pre C11 gcc >= 3.3 standard for thread-local variables
+#  elif defined _MSVC_VER
+#    define THREAD_LOCAL __declspec( thread )   ///< Microsoft Visual C thread local declaration
+#  else
+#    define THREAD_LOCAL                        ///< no thread-local variables
 #  endif
+#endif
 
 
 int novas_trace(const char *restrict loc, int n, int offset);


### PR DESCRIPTION
Until now, we used the CMake `find_library()` to detect if `libm` was present and should be used for linking. However as the discussion in https://github.com/microsoft/vcpkg/pull/50514 points out, `find_library()` may fail if the library is in `CMAKE_<LANG>_IMPLICIT_LINK_DIRECTORIES`. So switch to a different method a detecting `libm`.