### PR TITLE
Spherical offset positions

### DIFF
--- a/.settings/language.settings.xml
+++ b/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider copy-of="extension" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-1563840017389652703" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-1563587762567252703" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 Upcoming maintenance release, possibly around 1 August 2026.
 
+### Added
+
+ - #316: Spherical offset positions along a grat circle in specified direction and distance, based on the __astropy__
+   `offset_by()` function. Added `novas_offset_by()`, `novas_equ_offset_by()` functions; and `Equatorial::offset()`, 
+   `Ecliptic::offset()`, `Galactic::offset()`, and `Horizontal::offset()` methods. (thanks to aleberti)
+
 ### Changed
 
  - Improved CMake installation of examples (no unintended files, C++ examples only if `ENABLE_CPP` option is used). 

--- a/include/novas.h
+++ b/include/novas.h
@@ -69,10 +69,10 @@
 #define SUPERNOVAS_MAJOR_VERSION  1
 
 /// API minor version
-#define SUPERNOVAS_MINOR_VERSION  6
+#define SUPERNOVAS_MINOR_VERSION  7
 
 /// Integer sub version of the release
-#define SUPERNOVAS_PATCHLEVEL     1
+#define SUPERNOVAS_PATCHLEVEL     0
 
 /// Additional release information in version, e.g. "-1", or "-rc1", or empty string "" for releases.
 #define SUPERNOVAS_RELEASE_STRING "-devel"

--- a/include/novas.h
+++ b/include/novas.h
@@ -3384,6 +3384,16 @@ int novas_icrs_to_sys(const double *in, double jd_tdb, enum novas_accuracy accur
 int novas_sys_to_icrs(enum novas_reference_system sys, const double *in, double jd_tdb, enum novas_accuracy accuracy, double *out);
 
 
+// ---------------------- Added in 1.6.0 -------------------------
+
+// in util.c
+/// @c_util
+int novas_offset_by(double lon, double lat, double direction, double distance, double *restrict out_lon, double *restrict out_lat);
+
+/// @c_util
+int novas_equ_offset_by(double ra, double dec, double direction, double distance, double *restrict out_ra, double *restrict out_dec);
+
+
 // <================= END of SuperNOVAS API =====================>
 
 

--- a/include/supernovas.h
+++ b/include/supernovas.h
@@ -1030,6 +1030,10 @@ public:
 
   Angle distance_to(const Equatorial& other) const;
 
+  Equatorial offset(double direction_rad, double distance_rad) const;
+
+  Equatorial offset( const Angle& direction, const Angle& distance) const;
+
   Equatorial to_system(const Equinox& system, enum novas_accuracy accuracy = NOVAS_FULL_ACCURACY) const;
 
   Equatorial to_icrs() const;
@@ -1106,6 +1110,10 @@ public:
 
   Angle distance_to(const Ecliptic& other) const;
 
+  Ecliptic offset(double direction_rad, double distance_rad) const;
+
+  Ecliptic offset(const Angle& direction, const Angle& distance) const;
+
   Ecliptic to_system(const Equinox& system, enum novas_accuracy accuracy = NOVAS_FULL_ACCURACY) const;
 
   Ecliptic to_icrs() const;
@@ -1158,6 +1166,10 @@ public:
   bool operator!=(const Galactic& other) const;
 
   Angle distance_to(const Galactic& other) const;
+
+  Galactic offset(double direction_rad, double distance_rad) const;
+
+  Galactic offset(const Angle& direction, const Angle& distance) const;
 
   /// @ingroup equatorial
   Equatorial to_equatorial() const;
@@ -2653,6 +2665,10 @@ public:
   bool operator!=(const Horizontal& other) const;
 
   Angle distance_to(const Horizontal& other) const;
+
+  Horizontal offset(double direction_rad, double distance_rad) const;
+
+  Horizontal offset(const Angle& direction, const Angle& distance) const;
 
   const Angle& azimuth() const;
 

--- a/src/c99/util.c
+++ b/src/c99/util.c
@@ -999,9 +999,10 @@ int novas_print_dms(double degrees, enum novas_separator_type sep, int decimals,
 int novas_offset_by(double lon, double lat, double direction, double distance, double *restrict out_lon, double *restrict out_lat) {
   static const char *fn = "novas_offset_by";
 
+  const double eps = 1e-12;  // precision tolerance around poles
   double clat, slat, cD, sD_clat, cb;
 
-  if(fabs(lat) > 90.0)
+  if(fabs(lat) > 90.0 + eps)
     return novas_error(-1, EINVAL, fn, "latitude is outside of the [-90:90] range.");
 
   if(distance == 0.0) {
@@ -1015,17 +1016,17 @@ int novas_offset_by(double lon, double lat, double direction, double distance, d
 
   clat = cos(lat * DEGREE);
 
-  if(fabs(clat) < 1e-12) {
+  if(fabs(clat) < eps) {
     // Very close to the pole, longitude is undefined, but latitude can be determined
     // assuming that we start exactly from the pole.
     if(out_lat) {
-      *out_lat = remainder(distance, DEG360);
+      *out_lat = remainder(90.0 - distance, DEG360);
 
       // wrap as needed...
       if(*out_lat > 90.0)
-        *out_lat = 180.0 - lat;
+        *out_lat = 180.0 - *out_lat;
       else if(*out_lat < -90.0)
-        *out_lat = -180.0 - lat;
+        *out_lat = -180.0 - *out_lat;
     }
 
     if(out_lon) {

--- a/src/c99/util.c
+++ b/src/c99/util.c
@@ -715,6 +715,7 @@ double d_light(const double *pos_src, const double *pos_body) {
  * @author Attila Kovacs
  *
  * @sa novas_equ_sep(), novas_sun_angle(), novas_moon_angle()
+ * @sa novas_offset_by()
  */
 double novas_sep(double lon1, double lat1, double lon2, double lat2) {
   const double cp1 = cos(lat1 * DEGREE);
@@ -742,6 +743,7 @@ double novas_sep(double lon1, double lat1, double lon2, double lat2) {
  * @author Attila Kovacs
  *
  * @sa novas_sep(), novas_sun_angle(), novas_moon_angle()
+ * @sa novas_equ_offset_by()
  */
 double novas_equ_sep(double ra1, double dec1, double ra2, double dec2) {
   return novas_sep(15.0 * ra1, dec1, 15.0 * ra2, dec2);
@@ -971,3 +973,118 @@ int novas_print_dms(double degrees, enum novas_separator_type sep, int decimals,
   return strlen(buf);
 }
 
+/**
+ * Calculates offset spherical coordinates at some distance away from the input coordinates along
+ * a great circle which crosses the input position at the specified direction. Based on the
+ * __astropy__ `offset_by()` implementation.
+ *
+ * @param lon             [deg] reference point longitude
+ * @param lat             [deg] reference point latitude
+ * @param direction       [deg] direction (measured East of North).
+ * @param distance        [deg] offset distance on great circle
+ * @param[out] out_lon    [deg] longitude at offset position in [-&pi:&pi;) range. It may be NULL
+ *                        if not needed.
+ * @param[out] out_lat    [deg] latitude at offset position in [-&pi/2:&pi;/2] range. It may be
+ *                        NULL if not needed.
+ * @return                0 if successful, or else -1 if very close to the pole, and longitude at
+ *                        the offset position is requested, or if the input latitude is outside of
+ *                        the [-90:90] range.
+ *
+ * @since 1.7
+ * @sa Attila Kovacs
+ *
+ * @sa novas_equ_offset_by(), novas_sep()
+ * @sa https://docs.astropy.org/en/stable/_modules/astropy/coordinates/angles/utils.html#offset_at
+ */
+int novas_offset_by(double lon, double lat, double direction, double distance, double *restrict out_lon, double *restrict out_lat) {
+  static const char *fn = "novas_offset_by";
+
+  double clat, slat, cD, sD_clat, cb;
+
+  if(fabs(lat) > 90.0)
+    return novas_error(-1, EINVAL, fn, "latitude is outside of the [-90:90] range.");
+
+  if(distance == 0.0) {
+    // not offset at all...
+    if(out_lon)
+      *out_lon = lon;
+    if(out_lat)
+      *out_lat = lat;
+    return 0;
+  }
+
+  clat = cos(lat * DEGREE);
+
+  if(fabs(clat) < 1e-12) {
+    // Very close to the pole, longitude is undefined, but latitude can be determined
+    // assuming that we start exactly from the pole.
+    if(out_lat) {
+      *out_lat = remainder(distance, DEG360);
+
+      // wrap as needed...
+      if(*out_lat > 90.0)
+        *out_lat = 180.0 - lat;
+      else if(*out_lat < -90.0)
+        *out_lat = -180.0 - lat;
+    }
+
+    if(out_lon) {
+      *out_lon = NAN;
+      return novas_error(-1, EDOM, fn, "longitude is undefined at the poles");
+    }
+
+    return 0;
+  }
+
+  slat = sin(lat * DEGREE);
+  cD = cos(distance * DEGREE);
+  sD_clat = sin(distance * DEGREE) * clat;
+  cb = slat * cD + sD_clat * cos(direction * DEGREE);
+
+  if(out_lon) {
+    double dlon = atan2(sD_clat * sin(direction * DEGREE), cD - cb * slat) / DEGREE;
+    *out_lon = remainder(lon + dlon, DEG360);
+  }
+
+  if(out_lat)
+    *out_lat = asin(cb) / DEGREE;
+
+  return 0;
+}
+
+/**
+ * Calculates offset equatorial coordinates at some distance away from the input coordinates along
+ * a great circle which crosses the input position at the specified position angle.
+ *
+ * @param ra              [deg] reference point right ascention (R.A.)
+ * @param dec             [deg] reference point declination
+ * @param direction       [deg] direction (measured East of North).
+ * @param distance        [deg] offset distance on great circle
+ * @param[out] out_ra     [deg] right ascention (R.A.) at offset position in [0:24) range. It may
+ *                        be NULL if not needed.
+ * @param[out] out_dec    [deg] declination at offset position in [-&pi/2:&pi;/2] range. It may be
+ *                        NULL if not needed.
+ * @return                0 if successful, or else -1 if very close to the pole, and right
+ *                        ascention (R.A.) at the offset position is requested, or if the
+ *                        input declination is outside of the [-90:90] range.
+ *
+ * @since 1.7
+ * @sa Attila Kovacs
+ *
+ * @sa novas_offset_by(), novas_equ_sep()
+ */
+int novas_equ_offset_by(double ra, double dec, double direction, double distance, double *restrict out_ra, double *restrict out_dec) {
+  double out_lon = NAN;
+
+  int status = novas_offset_by(15.0 * ra, dec, direction, distance, &out_lon, out_dec);
+
+  if(out_lon < 0.0)
+    out_lon += DEG360;
+
+  if(out_ra)
+    *out_ra = out_lon / 15.0;
+
+  prop_error("novas_equ_offset", status, 0);
+
+  return 0;
+}

--- a/src/cpp/Ecliptic.cpp
+++ b/src/cpp/Ecliptic.cpp
@@ -297,7 +297,7 @@ Ecliptic Ecliptic::offset(double direction_rad, double distance_rad) const {
  * @sa distance_to(), Equatorial::offset(), Galactic::offset(), Horizontal::offset()
  */
 Ecliptic Ecliptic::offset(const Angle& direction, const Angle& distance) const {
-  return offset(distance.rad(), direction.rad());
+  return offset(direction.rad(), distance.rad());
 }
 
 /**

--- a/src/cpp/Ecliptic.cpp
+++ b/src/cpp/Ecliptic.cpp
@@ -253,12 +253,51 @@ Equinox Ecliptic::system() const {
  * @return        the angular distance of these coordinates to/from the argument.
  *
  * @since 1.6
+ *
+ * @sa offset_by()
  */
 Angle Ecliptic::distance_to(const Ecliptic& other) const {
   Angle a = Spherical::distance_to(other >> system());
   if(!a.is_valid())
     novas_trace_invalid("Ecliptic::distance_to()");
   return a;
+}
+
+/**
+ * Returns ecliptic coordinates for an offset position from these along the great circle that
+ * crosses these coordinates in the speciifed direction.
+ *
+ * @param direction_rad   [rad] offset direction, measured East of the local ecliptic North.
+ * @param distance_rad    [rad] offset great circle distance.
+ * @return                The ecliptic coordinates of the offset position
+ *
+ * @since 1.7
+ *
+ * @sa distance_to(), Equatorial::offset(), Galactic::offset(), Horizontal::offset()
+ */
+Ecliptic Ecliptic::offset(double direction_rad, double distance_rad) const {
+  double lon = NAN, lat = NAN;
+  novas_offset_by(longitude().deg(), latitude().deg(), direction_rad / Unit::deg, distance_rad / Unit::deg, &lon, &lat);
+  Ecliptic e(lon * Unit::deg, lat * Unit::deg, system());
+  if(!e.is_valid())
+    novas_trace_invalid("Ecliptic::offset()");
+  return e;
+}
+
+/**
+ * Returns ecliptic coordinates for an offset position from these along the great circle that
+ * crosses these coordinates in the speciifed direction.
+ *
+ * @param direction   offset direction, measured East of the local ecliptic North.
+ * @param distance    offset great circle distance.
+ * @return            The ecliptic coordinates of the offset position
+ *
+ * @since 1.7
+ *
+ * @sa distance_to(), Equatorial::offset(), Galactic::offset(), Horizontal::offset()
+ */
+Ecliptic Ecliptic::offset(const Angle& direction, const Angle& distance) const {
+  return offset(distance.rad(), direction.rad());
 }
 
 /**

--- a/src/cpp/Equatorial.cpp
+++ b/src/cpp/Equatorial.cpp
@@ -260,7 +260,7 @@ Equatorial Equatorial::offset(double direction_rad, double distance_rad) const {
  * @sa distance_to(), Ecliptic::offset(), Galactic::offset(), Horizontal::offset()
  */
 Equatorial Equatorial::offset(const Angle& direction, const Angle& distance) const {
-  return offset(distance.rad(), direction.rad());
+  return offset(direction.rad(), distance.rad());
 }
 
 /**

--- a/src/cpp/Equatorial.cpp
+++ b/src/cpp/Equatorial.cpp
@@ -214,12 +214,53 @@ enum novas_reference_system Equatorial::system_type() const {
  * @return        the angular distance of thereturn Angle::operator+(r);se coordinates to/from the argument.
  *
  * @since 1.6
+ *
+ * @sa offset_by()
  */
 Angle Equatorial::distance_to(const Equatorial& other) const {
   Angle a = Spherical::distance_to(other >> _sys);
   if(!a.is_valid())
     novas_trace_invalid("Equatorial::distance_to()");
   return a;
+}
+
+/**
+ * Returns equatorial coordinates for an offset position from these along the great circle that
+ * crosses these coordinates in the speciifed direction.
+ *
+ * @param direction_rad   [rad] offset direction, measured East of the local North.
+ * @param distance_rad    [rad] offset great circle distance.
+ *
+ * @return                The equatorial coordinates of the offset position
+ *
+ * @since 1.7
+ *
+ * @sa distance_to(), Ecliptic::offset(), Galactic::offset(), Horizontal::offset()
+ */
+Equatorial Equatorial::offset(double direction_rad, double distance_rad) const {
+  double lon = NAN, lat = NAN;
+  novas_offset_by(ra().deg(), dec().deg(), direction_rad / Unit::deg, distance_rad / Unit::deg, &lon, &lat);
+  Equatorial e(lon * Unit::deg, lat * Unit::deg, system());
+  if(!e.is_valid())
+    novas_trace_invalid("Equatorial::offset()");
+  return e;
+}
+
+/**
+ * Returns equatorial coordinates for an offset position from these along the great circle that
+ * crosses these coordinates in the speciifed direction.
+ *
+ * @param direction   offset direction, measured East of the local North.
+ * @param distance    offset great circle distance.
+ *
+ * @return            The equatorial coordinates of the offset position
+ *
+ * @since 1.7
+ *
+ * @sa distance_to(), Ecliptic::offset(), Galactic::offset(), Horizontal::offset()
+ */
+Equatorial Equatorial::offset(const Angle& direction, const Angle& distance) const {
+  return offset(distance.rad(), direction.rad());
 }
 
 /**

--- a/src/cpp/Galactic.cpp
+++ b/src/cpp/Galactic.cpp
@@ -194,7 +194,7 @@ Galactic Galactic::offset(double direction_rad, double distance_rad) const {
  * @sa distance_to(), Equatorial::offset(), Ecliptic::offset(), Horizontal::offset()
  */
 Galactic Galactic::offset(const Angle& direction, const Angle& distance) const {
-  return offset(distance.rad(), direction.rad());
+  return offset(direction.rad(), distance.rad());
 }
 
 /**

--- a/src/cpp/Galactic.cpp
+++ b/src/cpp/Galactic.cpp
@@ -150,12 +150,51 @@ bool Galactic::operator!=(const Galactic& other) const {
  * @return        the angular distance of these coordinates to/from the argument.
  *
  * @since 1.6
+ *
+ * @sa offset_by()
  */
 Angle Galactic::distance_to(const Galactic& other) const {
   Angle a = Spherical::distance_to(other);
   if(!a.is_valid())
     novas_trace_invalid("Galactic::distance_to()");
   return a;
+}
+
+/**
+ * Returns galactic coordinates for an offset position from these along the great circle that
+ * crosses these coordinates in the speciifed direction.
+ *
+ * @param direction_rad   [rad] offset direction, measured East of the local galactic North.
+ * @param distance_rad    [rad] offset great circle distance.
+ * @return                The galactic coordinates of the offset position
+ *
+ * @since 1.7
+ *
+ * @sa distance_to(), Equatorial::offset(), Ecliptic::offset(), Horizontal::offset()
+ */
+Galactic Galactic::offset(double direction_rad, double distance_rad) const {
+  double lon = NAN, lat = NAN;
+  novas_offset_by(longitude().deg(), latitude().deg(), direction_rad / Unit::deg, distance_rad / Unit::deg, &lon, &lat);
+  Galactic g(lon * Unit::deg, lat * Unit::deg);
+  if(!g.is_valid())
+    novas_trace_invalid("Galactic::offset()");
+  return g;
+}
+
+/**
+ * Returns galactic coordinates for an offset position from these along the great circle that
+ * crosses these coordinates in the speciifed direction.
+ *
+ * @param direction   offset direction, measured East of the local galactic North.
+ * @param distance    offset great circle distance.
+ * @return            The galactic coordinates of the offset position
+ *
+ * @since 1.7
+ *
+ * @sa distance_to(), Equatorial::offset(), Ecliptic::offset(), Horizontal::offset()
+ */
+Galactic Galactic::offset(const Angle& direction, const Angle& distance) const {
+  return offset(distance.rad(), direction.rad());
 }
 
 /**

--- a/src/cpp/Horizontal.cpp
+++ b/src/cpp/Horizontal.cpp
@@ -222,7 +222,7 @@ Horizontal Horizontal::offset(double direction_rad, double distance_rad) const {
  * @sa distance_to(), Equatorial::offset(), Galactic::offset(), Ecliptic::offset()
  */
 Horizontal Horizontal::offset(const Angle& direction, const Angle& distance) const {
-  return offset(distance.rad(), direction.rad());
+  return offset(direction.rad(), distance.rad());
 }
 
 /**

--- a/src/cpp/Horizontal.cpp
+++ b/src/cpp/Horizontal.cpp
@@ -178,12 +178,51 @@ bool Horizontal::operator!=(const Horizontal& other) const {
  * @return        the angular distance of these coordinates to/from the argument.
  *
  * @since 1.6
+ *
+ * @sa offset_by()
  */
 Angle Horizontal::distance_to(const Horizontal& other) const {
   Angle a = Spherical::distance_to(other);
   if(!a.is_valid())
     novas_trace_invalid("Horizontal::distance_to()");
   return a;
+}
+
+/**
+ * Returns horizontal coordinates for an offset position from these along the great circle that
+ * crosses these coordinates in the speciifed direction.
+ *
+ * @param direction_rad   [rad] offset direction, measured East of the local North.
+ * @param distance_rad    [rad] offset great circle distance.
+ * @return                The horizontal coordinates of the offset position
+ *
+ * @since 1.7
+ *
+ * @sa ditance_to(), Equatorial::offset(), Galactic::offset(), Ecliptic::offset()
+ */
+Horizontal Horizontal::offset(double direction_rad, double distance_rad) const {
+  double lon = NAN, lat = NAN;
+  novas_offset_by(longitude().deg(), latitude().deg(), direction_rad / Unit::deg, distance_rad / Unit::deg, &lon, &lat);
+  Horizontal h(lon * Unit::deg, lat * Unit::deg);
+  if(!h.is_valid())
+    novas_trace_invalid("Horizontal::offset()");
+  return h;
+}
+
+/**
+ * Returns horizontal coordinates for an offset position from these along the great circle that
+ * crosses these coordinates in the speciifed direction.
+ *
+ * @param direction   offset direction, measured East of the local North.
+ * @param distance    offset great circle distance.
+ * @return            The horizontal coordinates of the offset position
+ *
+ * @since 1.7
+ *
+ * @sa distance_to(), Equatorial::offset(), Galactic::offset(), Ecliptic::offset()
+ */
+Horizontal Horizontal::offset(const Angle& direction, const Angle& distance) const {
+  return offset(distance.rad(), direction.rad());
 }
 
 /**

--- a/test/c99/test-errors.c
+++ b/test/c99/test-errors.c
@@ -2723,6 +2723,17 @@ static int test_sys_to_gcrs() {
   return n;
 }
 
+static int test_offset_by() {
+  int n = 0;
+  double lon = 0.0, lat = 0.0;
+
+  if(check("offset_by:+91", -1, novas_offset_by(lon, 91.0, 0.0, 1.0, &lon, &lat))) n++;
+  if(check("offset_by:-91", -1, novas_offset_by(lon, -91.0, 0.0, 1.0, &lon, &lat))) n++;
+  if(check("offset_by:90:lon", -1, novas_offset_by(lon, 90.0, 0.0, 1.0, &lon, &lat))) n++;
+
+  return n;
+}
+
 
 int main(int argc, const char *argv[]) {
   int n = 0;
@@ -2957,6 +2968,8 @@ int main(int argc, const char *argv[]) {
   if(test_timescale_offset()) n++;
   if(test_gcrs_to_sys()) n++;
   if(test_sys_to_gcrs()) n++;
+
+  if(test_offset_by()) n++;
 
   if(n) fprintf(stderr, " -- FAILED %d tests\n", n);
   else fprintf(stderr, " -- OK\n");

--- a/test/c99/test-super.c
+++ b/test/c99/test-super.c
@@ -5192,6 +5192,71 @@ static int test_sys_to_gcrs() {
   return 0;
 }
 
+static int test_offset_by() {
+  int n = 0;
+
+  double lon = 0.0, lat = 0.0;
+
+  if(!is_ok("offset_by:d=0", novas_offset_by(15.0, 30.0, 0.0, 0.0, &lon, &lat))) n++;
+  if(!is_equal("offset:by:d=0:lon", 15.0, lon, 1e-14)) n++;
+  if(!is_equal("offset:by:d=0:lat", 30.0, lat, 1e-14)) n++;
+
+  if(!is_ok("offset_by:d=0:lon-only", novas_offset_by(15.0, 30.0, 0.0, 0.0, &lon, NULL))) n++;
+  if(!is_equal("offset:by:d=0:lon", 15.0, lon, 1e-14)) n++;
+
+  if(!is_ok("offset_by:d=0:lat-only", novas_offset_by(15.0, 30.0, 0.0, 0.0, NULL, &lat))) n++;
+  if(!is_equal("offset:by:d=0:lat", 30.0, lat, 1e-14)) n++;
+
+  if(!is_ok("offset_by:N", novas_offset_by(15.0, 30.0, 0.0, 1.0, &lon, &lat))) n++;
+  if(!is_equal("offset:by:N:lon", 15.0, lon, 1e-14)) n++;
+  if(!is_equal("offset:by:N:lat", 31.0, lat, 1e-14)) n++;
+
+  if(!is_ok("offset_by:N:lon-only", novas_offset_by(15.0, 30.0, 0.0, 1.0, &lon, NULL))) n++;
+  if(!is_equal("offset:by:N:lon", 15.0, lon, 1e-14)) n++;
+
+  if(!is_ok("offset_by:N:lat-only", novas_offset_by(15.0, 30.0, 0.0, 1.0, NULL, &lat))) n++;
+  if(!is_equal("offset:by:N:lat", 31.0, lat, 1e-14)) n++;
+
+  if(!is_ok("offset_by:E", novas_offset_by(15.0, 0.0, 90.0, 1.0, &lon, &lat))) n++;
+  if(!is_equal("offset:by:E:lon", 16.0, lon, 1e-14)) n++;
+  if(!is_equal("offset:by:E:lat", 0.0, lat, 1e-14)) n++;
+
+  if(!is_ok("offset_by:N:over", novas_offset_by(15.0, 30.0, 0.0, 119.0, &lon, &lat))) n++;
+  if(!is_equal("offset:by:N:over:lon", -165.0, lon, 1e-14)) n++;
+  if(!is_equal("offset:by:N:over:lat", 31.0, lat, 1e-14)) n++;
+
+  if(!is_ok("offset_by:pole:N:d=0", novas_offset_by(15.0, 90.0, 0.0, 0.0, &lon, &lat))) n++;
+  if(!is_equal("offset:by:N:d=0:lon", 15.0, lon, 1e-14)) n++;
+  if(!is_equal("offset:by:N:d=0:lat", 90.0, lat, 1e-14)) n++;
+
+  if(!is_ok("offset_by:pole:N", novas_offset_by(15.0, 90.0, 0.0, 1.0, NULL, &lat))) n++;
+  if(!is_equal("offset:by:N:lat", 89.0, lat, 1e-14)) n++;
+
+  if(!is_ok("offset_by:pole:N", novas_offset_by(15.0, 90.0, 0.0, 181.0, NULL, &lat))) n++;
+  if(!is_equal("offset:by:N:lat", -89.0, lat, 1e-14)) n++;
+
+  if(!is_ok("offset_by:pole:N", novas_offset_by(15.0, 90.0, 0.0, -361.0, NULL, &lat))) n++;
+  if(!is_equal("offset:by:N:lat", 89.0, lat, 1e-14)) n++;
+
+  return n;
+}
+
+static int test_equ_offset_by() {
+  int n = 0;
+
+  double ra = 0.0, dec = 0.0;
+
+  if(!is_ok("equ_offset_by:N", novas_equ_offset_by(15.0, 30.0, 0.0, 1.0, &ra, &dec))) n++;
+  if(!is_equal("equ_offset:by:N:ra", 15.0, ra, 1e-14)) n++;
+  if(!is_equal("equ_offset:by:N:dec", 31.0, dec, 1e-14)) n++;
+
+  if(!is_ok("equ_offset_by:E", novas_equ_offset_by(15.0, 0.0, 90.0, 15.0, &ra, &dec))) n++;
+  if(!is_equal("equ_offset:by:E:ra", 16.0, ra, 1e-14)) n++;
+  if(!is_equal("equ_offset:by:E:dec", 0.0, dec, 1e-14)) n++;
+
+  return n;
+}
+
 int main(int argc, char *argv[]) {
   int n = 0;
 
@@ -5306,7 +5371,6 @@ int main(int argc, char *argv[]) {
   if(test_jd_from_date()) n++;
 
   if(test_epoch()) n++;
-
   if(test_print_hms()) n++;
   if(test_print_dms()) n++;
 
@@ -5363,6 +5427,9 @@ int main(int argc, char *argv[]) {
   if(test_timescale_offset()) n++;
   if(test_gcrs_to_sys()) n++;
   if(test_sys_to_gcrs()) n++;
+
+  if(test_offset_by()) n++;
+  if(test_equ_offset_by()) n++;
 
   n += test_dates();
 

--- a/test/cpp/EclipticTest.cpp
+++ b/test/cpp/EclipticTest.cpp
@@ -46,6 +46,17 @@ int main() {
   if(!test.check("distance_to(invalid)", !a.distance_to(x).is_valid())) n++;
   if(!test.check("to_system(invalid equinox)", !a.to_system(Equinox::undefined()).is_valid())) n++;
 
+  Ecliptic ao = a.offset(Angle(30.0 * Unit::deg), Angle(1.5 * Unit::deg));
+  if(!test.check("offset()", ao.is_valid())) n++;
+  double olon = 0.0, olat = 0.0;
+  novas_offset_by(a.longitude().deg(), a.latitude().deg(), 30.0, 1.5, &olon, &olat);
+  if(!test.equals("offset().longitude()", ao.longitude().deg(), olon, 1e-14)) n++;
+  if(!test.equals("offset().latitude()", ao.latitude().deg(), olat, 1e-14)) n++;
+  if(!test.check("offset().system()", ao.system() == a.system())) n++;
+  if(!test.equals("offset().distance_to()", ao.distance_to(a).deg(), 1.5, 1e-14)) n++;
+
+  if(!test.check("offset(pole)", !Ecliptic(150.0 * Unit::deg, 90.0 * Unit::deg).offset(10.0, 2.0).is_valid())) n++;
+
   Ecliptic a1 = Ecliptic("45:00 00.000", "30d 00m00s", Equinox::icrs());
   if(!test.check("is_valid() Ecliptic(string)", a1.is_valid())) n++;
   if(!test.check("equals(Angle) Ecliptic(string)", a1.equals(a, Angle(1e-15)))) n++;

--- a/test/cpp/EquatorialTest.cpp
+++ b/test/cpp/EquatorialTest.cpp
@@ -44,6 +44,17 @@ int main() {
   if(!test.check("distance_to() invalid", !x.distance_to(a).is_valid())) n++;
   if(!test.check("invalid.distance_to()", !a.distance_to(x).is_valid())) n++;
 
+  Equatorial ao = a.offset(Angle(30.0 * Unit::deg), Angle(1.5 * Unit::deg));
+  if(!test.check("offset()", ao.is_valid())) n++;
+  double ora = 0.0, odec = 0.0;
+  novas_equ_offset_by(a.ra().hours(), a.dec().deg(), 30.0, 1.5, &ora, &odec);
+  if(!test.equals("offset().ra()", ao.ra().hours(), ora, 1e-14)) n++;
+  if(!test.equals("offset().dec()", ao.dec().deg(), odec, 1e-14)) n++;
+  if(!test.check("offset().system()", ao.system() == a.system())) n++;
+  if(!test.equals("offset().distance_to()", ao.distance_to(a).deg(), 1.5, 1e-14)) n++;
+
+  if(!test.check("offset(pole)", !Equatorial(150.0 * Unit::deg, 90.0 * Unit::deg).offset(10.0, 2.0).is_valid())) n++;
+
   double p0[3] = {0.0}, z[3] = {0.0};
   Position pos(z, Unit::pc);
   double *p1 = (double *) pos._array();

--- a/test/cpp/GalacticTest.cpp
+++ b/test/cpp/GalacticTest.cpp
@@ -37,6 +37,16 @@ int main() {
   if(!test.check("distance_to(invalid)", !a.distance_to(x).is_valid())) n++;
   if(!test.check("invalid.distance_to()", !x.distance_to(a).is_valid())) n++;
 
+  Galactic ao = a.offset(Angle(30.0 * Unit::deg), Angle(1.5 * Unit::deg));
+  if(!test.check("offset()", ao.is_valid())) n++;
+  double olon = 0.0, olat = 0.0;
+  novas_offset_by(a.longitude().deg(), a.latitude().deg(), 30.0, 1.5, &olon, &olat);
+  if(!test.equals("offset().longitude()", ao.longitude().deg(), olon, 1e-14)) n++;
+  if(!test.equals("offset().latitude()", ao.latitude().deg(), olat, 1e-14)) n++;
+  if(!test.equals("offset().distance_to()", ao.distance_to(a).deg(), 1.5, 1e-14)) n++;
+
+  if(!test.check("offset(pole)", !Galactic(150.0 * Unit::deg, 90.0 * Unit::deg).offset(10.0, 2.0).is_valid())) n++;
+
   Galactic a1("45d00:00.000", "+30 00m 00");
   if(!test.check("is_valid(string)", a1.is_valid())) n++;
   if(!test.check("is_equals(string)", a1.equals(a))) n++;

--- a/test/cpp/HorizontalTest.cpp
+++ b/test/cpp/HorizontalTest.cpp
@@ -37,6 +37,16 @@ int main() {
   if(!test.check("invalid.distance_to()", !x.distance_to(a).is_valid())) n++;
   if(!test.equals("to_string()", a.to_string(), "HOR  -20d 00m 00.000s  -30d 00m 00.000s")) n++;
 
+  Horizontal ao = a.offset(Angle(30.0 * Unit::deg), Angle(1.5 * Unit::deg));
+  if(!test.check("offset()", ao.is_valid())) n++;
+  double olon = 0.0, olat = 0.0;
+  novas_offset_by(a.longitude().deg(), a.latitude().deg(), 30.0, 1.5, &olon, &olat);
+  if(!test.equals("offset().longitude()", ao.longitude().deg(), olon, 1e-14)) n++;
+  if(!test.equals("offset().latitude()", ao.latitude().deg(), olat, 1e-14)) n++;
+  if(!test.equals("offset().distance_to()", ao.distance_to(a).deg(), 1.5, 1e-14)) n++;
+
+  if(!test.check("offset(pole)", !Horizontal(150.0 * Unit::deg, 90.0 * Unit::deg).offset(10.0, 2.0).is_valid())) n++;
+
   Site site(15.0 * Unit::deg, -42.0 * Unit::deg, 1.5 * Unit::km);
   Horizontal a1 = a.to_refracted(novas_standard_refraction, site.average_weather());
   on_surface s = *site._on_surface();


### PR DESCRIPTION
Added functions / methods to calculate offset spherical positions from the reference position along a great circle, which crosses the reference at a specified direction. It is based on the __astropy__ `offset_by()` implementation. (thanks to @aleberti).


## C99 API

### Added

- `novas_offset_by()` and `novas_equ_offset_by()` to calculate offset spherical / equatorial positions at some distance along a great circle that intersects the original position at the specified angle.

## C++11 API

### Added

- `Equatorial::offset()`, `Ecliptic::offset()`, `Galactic::offset()`, and `Horizontal::offset()`.