### PR TITLE
Consolidate mutexes with novas-mutex.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Upcoming feature release, possibly around 1 August 2026.
    
  - #318: `CatalogEntry`, `OrbitalSystem`, `Orbital`, `Source`, `Observer`, and `Frame` now have `equals()` methods
    as well as overridden `==` and `!=` operators, thanks to the new C99 comparison functions.
+   
+ - #319: Consolidate portable mutex definitions in `novas-mutex.h` (not installed).
 
 ### Changed
 
@@ -46,6 +48,9 @@ Upcoming feature release, possibly around 1 August 2026.
 
  - #318: `Vector::equals()` to use the new `novas_equals_vector()` for consitent implementation between the C99 and 
    C++ APIs.
+   
+ - #319: Updated `novas-calceph.c`, `novas-cspice.c`, and `iers.c` to use portable mutex definitions from 
+   `novas.mutex.h`.
 
  - Improved CMake installation of examples (no unintended files, C++ examples only if `ENABLE_CPP` option is used). 
 

--- a/include/novas-mutex.h
+++ b/include/novas-mutex.h
@@ -1,0 +1,60 @@
+/**
+ * @file
+ *
+ * @date Created  on Apr 10, 2026
+ * @author Attila Kovacs
+ *
+ *  Portable mutex function mappings for SuperNOVAS
+ */
+
+#ifndef NOVAS_MUTEX_H_
+#define NOVAS_MUTEX_H_
+
+/// \cond PROTECTED
+#if defined(SUPERNOVAS_USE_PTHREAD) || defined(__unix__) || defined(__unix) || defined(__APPLE__)
+#  include <pthread.h>
+
+#  define novas_init_lock(x)    pthread_mutex_init(x, NULL)
+#  define novas_lock            pthread_mutex_lock
+#  define novas_unlock          pthread_mutex_unlock
+#  define novas_destroy_lock    pthread_mutex_destroy
+#  define THREAD_SAFE           1
+
+typedef pthread_mutex_t       lock_type;
+
+#elif __STDC_VERSION__ >= 201112L
+#  include <threads.h>
+
+#  define novas_init_lock(x)    mtx_init(x, mtx_plain)
+#  define novas_lock            mtx_lock
+#  define novas_unlock          mtx_unlock
+#  define novas_destroy_lock    mtx_destroy
+
+#  define THREAD_SAFE           1
+
+typedef mtx_t                   lock_type;
+
+#elif defined(WIN32)
+#include <windows.h>
+
+#  define novas_init_lock(x)    InitializeSRWLock(x)
+#  define novas_lock            AcquireSRWLockExclusive
+#  define novas_unlock          ReleaseSRWLockExclusive
+#  define novas_destroy_lock(x)
+#  define THREAD_SAFE           1
+
+typedef SRWLOCK                 lock_type;
+
+#else
+#  define novas_lock(x)
+#  define novas_unlock(x)
+#  define novas_destroy_lock(x)
+#  define THREAD_SAFE           0
+
+typedef int                     lock_type;
+
+#endif
+/// \endcond
+
+
+#endif /* NOVAS_MUTEX_H_ */

--- a/src/c99/iers.c
+++ b/src/c99/iers.c
@@ -28,52 +28,7 @@
 /// \endcond
 
 #include "novas.h"
-
-/// \cond PRIVATE
-#if defined(SUPERNOVAS_USE_PTHREAD) || defined(__unix__) || defined(__unix) || defined(__APPLE__)
-#  include <pthread.h>
-
-#  define novas_init_lock(x)    pthread_mutex_init(x, NULL)
-#  define novas_lock            pthread_mutex_lock
-#  define novas_unlock          pthread_mutex_unlock
-#  define novas_destroy_lock    pthread_mutex_destroy
-#  define THREAD_SAFE           1
-
-typedef pthread_mutex_t       lock_type;
-
-#elif __STDC_VERSION__ >= 201112L
-#  include <threads.h>
-
-#  define novas_init_lock(x)    mtx_init(x, mtx_plain)
-#  define novas_lock            mtx_lock
-#  define novas_unlock          mtx_unlock
-#  define novas_destroy_lock    mtx_destroy
-
-#  define THREAD_SAFE           1
-
-typedef mtx_t                   lock_type;
-
-#elif defined(WIN32)
-#include <windows.h>
-
-#  define novas_init_lock(x)    InitializeSRWLock(x)
-#  define novas_lock            AcquireSRWLockExclusive
-#  define novas_unlock          ReleaseSRWLockExclusive
-#  define novas_destroy_lock(x)
-#  define THREAD_SAFE           1
-
-typedef SRWLOCK                 lock_type;
-
-#else
-#  define novas_lock(x)
-#  define novas_unlock(x)
-#  define novas_destroy_lock(x)
-#  define THREAD_SAFE           0
-
-typedef int                     lock_type;
-
-#endif
-/// \endcond
+#include "novas-mutex.h"
 
 /// \cond PRIVATE
 

--- a/src/c99/solsys-calceph.c
+++ b/src/c99/solsys-calceph.c
@@ -58,53 +58,13 @@
 #include <errno.h>
 
 /// \cond PRIVATE
-#if defined(SUPERNOVAS_USE_PTHREAD) || defined(__unix__) || defined(__unix) || defined(__APPLE__)
-#  include <pthread.h>
-
-#  define init_lock(x)        pthread_mutex_init(x, (void *) 0)
-#  define ephem_lock          pthread_mutex_lock
-#  define ephem_unlock        pthread_mutex_unlock
-#  define THREAD_SAFE         1
-
-typedef pthread_mutex_t       lock_type;
-
-#elif __STDC_VERSION__ >= 201112L
-#  include <threads.h>
-
-#  define init_lock (x)       mtx_init(x, mtx_plain)
-#  define ephem_lock          mtx_lock
-#  define ephem_unlock        mtx_unlock
-
-#  define THREAD_SAFE         1
-
-typedef mtx_t                 lock_type;
-
-#elif defined(WIN32)
-#include <windows.h>
-
-#  define init_lock(x)        InitializeSRWLock(x)
-#  define ephem_lock          AcquireSRWLockExclusive
-#  define ephem_unlock        ReleaseSRWLockExclusive
-#  define THREAD_SAFE         1
-
-typedef SRWLOCK               lock_type;
-
-#else
-#  define ephem_lock(x)
-#  define ephem_unlock(x)
-#  define THREAD_SAFE         0
-typedef int                   lock_type;
-
-#endif
-
 #define __NOVAS_INTERNAL_API__      ///< Use definitions meant for internal use by SuperNOVAS only
-/// \endcond
 
 #include "novas.h"
 #include "novas-calceph.h"
+#include "novas-mutex.h"
 
 
-/// \cond PRIVATE
 #define CALCEPH_MOON                10  ///< Moon in CALCEPH
 #define CALCEPH_SUN                 11  ///< Sun in CALCEPH
 #define CALCEPH_SSB                 12  ///< Solar-system Barycenter in CALCEPH
@@ -262,22 +222,22 @@ static short planet_calceph_hp(const double jd_tdb[restrict 2], enum novas_plane
       return novas_error(2, EINVAL, fn, "Invalid origin type: %d", origin);
   }
 
-  ephem_lock(&planet_mutex);
+  novas_lock(&planet_mutex);
   ephem = planets;
 
   parallel = !serialized_calceph_queries && calceph_isthreadsafe(ephem);
   if(parallel)
-    ephem_unlock(&planet_mutex);      // If CALCEPH itself is thread-safe we can release the lock here...
+    novas_unlock(&planet_mutex);      // If CALCEPH itself is thread-safe we can release the lock here...
   else if(ephem == bodies)
-    ephem_lock(&bodies_mutex);        // Otherwise, we might need to get exclusive on the bodies also....
+    novas_lock(&bodies_mutex);        // Otherwise, we might need to get exclusive on the bodies also....
 
   success = calceph_compute_unit(ephem, jd_tdb[0], jd_tdb[1], target, center, CALCEPH_UNITS, pv);
 
   // If CALCEPH is not thread-safe on its own, release the lock after the ephemeris access...
   if(!parallel) {
     if(ephem == bodies)
-      ephem_unlock(&bodies_mutex);    // If no separate planet ephemeris, then release the lock on the bodies also.
-    ephem_unlock(&planet_mutex);      // release the lock on planet ephemeris access.
+      novas_unlock(&bodies_mutex);    // If no separate planet ephemeris, then release the lock on the bodies also.
+    novas_unlock(&planet_mutex);      // release the lock on planet ephemeris access.
   }
 
   if(!success)
@@ -400,19 +360,19 @@ static int novas_calceph(const char *name, long id, double jd_tdb_high, double j
 
   center = (compute_flags & CALCEPH_USE_NAIFID) ? NAIF_SSB : CALCEPH_SSB;
 
-  ephem_lock(&bodies_mutex);
+  novas_lock(&bodies_mutex);
   ephem = bodies;
 
   // If CALCEPH itself is thread-safe we can release the lock here...
   parallel = !serialized_calceph_queries && calceph_isthreadsafe(ephem);
   if(parallel)
-    ephem_unlock(&bodies_mutex);
+    novas_unlock(&bodies_mutex);
 
   success = calceph_compute_unit(ephem, jd_tdb_high, jd_tdb_low, id, center, (compute_flags | CALCEPH_UNITS), pv);
 
   // If CALCEPH is not thread-safe on its own, release the lock after the ephemeris access...
   if(!parallel)
-    ephem_unlock(&bodies_mutex);
+    novas_unlock(&bodies_mutex);
 
   if(!success)
     return novas_error(3, EAGAIN, fn, "calceph_compute() failure (name='%s', NAIF=%ld)", name ? name : "<null>", id);
@@ -453,7 +413,7 @@ int novas_use_calceph(t_calcephbin *eph) {
   static int initialized = 0;
 
   if(!initialized) {
-    init_lock(&bodies_mutex);
+    novas_init_lock(&bodies_mutex);
     initialized = 1;
   }
 #endif
@@ -461,9 +421,9 @@ int novas_use_calceph(t_calcephbin *eph) {
   prop_error(fn, prep_ephem(eph), 0);
 
   // Make sure we don't change the ephemeris provider while using it
-  ephem_lock(&bodies_mutex);
+  novas_lock(&bodies_mutex);
   bodies = eph;
-  ephem_unlock(&bodies_mutex);
+  novas_unlock(&bodies_mutex);
 
   // Use CALCEPH as the default minor body ephemeris provider
   set_ephem_provider(novas_calceph);
@@ -496,7 +456,7 @@ int novas_use_calceph_planets(t_calcephbin *eph) {
   static int initialized = 0;
 
   if(!initialized) {
-    init_lock(&planet_mutex);
+    novas_init_lock(&planet_mutex);
     initialized = 1;
   }
 #endif
@@ -504,9 +464,9 @@ int novas_use_calceph_planets(t_calcephbin *eph) {
   prop_error(fn, prep_ephem(eph), 0);
 
   // Make sure we don't change the ephemeris provider while using it
-  ephem_lock(&planet_mutex);
+  novas_lock(&planet_mutex);
   planets = eph;
-  ephem_unlock(&planet_mutex);
+  novas_unlock(&planet_mutex);
 
   // Use calceph as the default NOVAS planet provider
   set_planet_provider_hp(planet_calceph_hp);

--- a/src/c99/solsys-cspice.c
+++ b/src/c99/solsys-cspice.c
@@ -59,57 +59,16 @@
 #include <errno.h>
 
 /// \cond PRIVATE
-#if defined(SUPERNOVAS_USE_PTHREAD) || defined(__unix__) || defined(__unix) || defined(__APPLE__)
-#  include <pthread.h>
-
-#  define init_lock(x)        pthread_mutex_init(x, (void *) 0)
-#  define ephem_lock          pthread_mutex_lock
-#  define ephem_unlock        pthread_mutex_unlock
-#  define THREAD_SAFE         1
-
-typedef pthread_mutex_t       lock_type;
-
-#elif __STDC_VERSION__ >= 201112L
-#  include <threads.h>
-
-#  define init_lock(x)        mtx_init(x, mtx_plain)
-#  define ephem_lock          mtx_lock
-#  define ephem_unlock        mtx_unlock
-
-#  define THREAD_SAFE         1
-
-typedef mtx_t                 lock_type;
-
-#elif defined(WIN32)
-#include <windows.h>
-
-#  define init_lock(x)        InitializeSRWLock(x)
-#  define ephem_lock          AcquireSRWLockExclusive
-#  define ephem_unlock        ReleaseSRWLockExclusive
-#  define THREAD_SAFE         1
-
-typedef SRWLOCK               lock_type;
-
-#else
-#  define ephem_lock(x)
-#  define ephem_unlock(x)
-#  define THREAD_SAFE         0
-
-typedef int                   lock_type;
-
-#endif
-
-
 #define __NOVAS_INTERNAL_API__      ///< Use definitions meant for internal use by SuperNOVAS only
-/// \endcond
 
 #include "novas.h"
 #include "novas-cspice.h"
+#include "novas-mutex.h"
 
 #include "cspice/SpiceUsr.h"
 #include "cspice/SpiceZpr.h"        // for reset_c
 
-/// \cond PRIVATE
+
 /// Multiplicative normalization for the positions returned by km to AU
 #define NORM_POS                    (NOVAS_KM / NOVAS_AU)
 
@@ -125,15 +84,15 @@ static void mutex_lock() {
   static int initialized;
 
   if(!initialized) {
-    init_lock(&mutex);
+    novas_init_lock(&mutex);
     initialized = 1;
   }
 
-  ephem_lock(&mutex);
+  novas_lock(&mutex);
 }
 
 static void mutex_unlock() {
-  ephem_unlock(&mutex);
+  novas_unlock(&mutex);
 }
 #endif
 
@@ -474,38 +433,6 @@ static short planet_cspice(double jd_tdb, enum novas_planet body, enum novas_ori
  *                      calculations, or else the entire Julian date for reduced precision.
  * @param jd_tdb_low    [day] The low-order part of Barycentric Dynamical Time (TDB) based
  *                      Julian date for which to find #if defined(_PTHREAD_) || defined(__unix__) || defined(__unix) || defined(__APPLE__)
-#  include <pthread.h>
-
-#  define mutex_init      pthread_mutex_init
-#  define mutex_lock      pthread_mutex_lock
-#  define mutex_unlock    pthread_mutex_unlock
-#  define THREAD_SAFE     1
-
-typedef pthread_mutex_t   mtx_t;
-
-#elif __STDC_VERSION__ >= 201112L
-#  include <threads.h>
-#  define mutex_init      mtx_init
-#  define mutex_lock      mtx_lock
-#  define mutex_unlock    mtx_unlock
-
-#  define THREAD_SAFE     1
-
-#elif defined(WIN32)
-#include <windows.h>
-#  define mutex_init      InitializeSRWLock
-#  define mutex_lock      AcquireSRWLockExclusive
-#  define mutex_unlock    ReleaseSRWLockExclusive
-#  define THREAD_SAFE     1
-
-#else
-#  define mtx_lock        (void)
-#  define mtx_unlock      (void)
-#  define THREAD_SAFE     0
-
-typedef int               mtx_t;
-
-#endif
  *                      the position and velocity. Typically
  *                      this may be the fractional part of the Julian date for high-precision
  *                      calculations, or else 0.0 if the date is defined entirely by the


### PR DESCRIPTION
### Added

 - `novas-mutex.h` -- containing portable mutex definitions.

### Changed

 - `novas-calceph.c`, `novas-cspice.c`, and `iers.c` to use portable mutex definitions from new `novas-mutex.h`