### PR TITLE
Improved builds with and without cURL support

### DIFF
--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -40,7 +40,12 @@ jobs:
           sudo apt-get install -y libcurl4-openssl-dev
 
       - name: Configure CMake (Unix)
+        if: runner.os != 'Windows'
         run: cmake -B build -DENABLE_CPP=ON -DBUILD_SHARED_LIBS=ON -DBUILD_EXAMPLES=ON -DBUILD_BENCHMARK=ON
+
+      - name: Configure CMake (Windows)
+        if: runner.os == 'Windows'
+        run: cmake -B build -DWITHOUT_CURL=ON -DENABLE_CPP=ON -DBUILD_SHARED_LIBS=ON -DBUILD_EXAMPLES=ON -DBUILD_BENCHMARK=ON
 
       - name: Build (Unix)
         if: runner.os != 'Windows'
@@ -77,7 +82,7 @@ jobs:
           release: "14.0"
           usesh: true
           prepare: |
-            pkg install -y cmake
+            pkg install -y cmake curl
           run: |
             echo Building on FreeBSD $(uname -m)
             cmake -B build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ option(BUILD_DOC "Build HTML documetation" OFF)
 option(BUILD_TESTING "Build regression test suite" ON)
 option(BUILD_EXAMPLES "Build example programs" OFF)
 option(BUILD_BENCHMARK "Build benchmark programs" OFF)
+option(WITHOUT_CURL "Build withour cURL support (no fetching EOP from IERS possible)" ON)
 option(ENABLE_CPP "Enable C++ library build (supernovas++ library)" OFF)
 option(ENABLE_CALCEPH "Enable CALCEPH support (solsys-calceph plugin)" OFF)
 option(ENABLE_CSPICE "Enable CSPICE support (solsys-cspice plugin)" OFF)
@@ -53,6 +54,8 @@ add_feature_info(Documentation BUILD_DOC "Developer documentation (HTML)")
 add_feature_info(Testing BUILD_TESTING "Run regression testing")
 add_feature_info(Examples BUILD_EXAMPLES "Build and test example programs")
 add_feature_info(Benchmarks BUILD_BENCHMARK "Build benchmarking programs")
+
+add_feature_info(Without-cURL WITHOUT_CURL "Build with cURL support (no fetching EOP from IERS possible)")
 
 add_feature_info(C++-Libs ENABLE_CPP "Build C++ library also (supernovas++)")
 add_feature_info(Calceph-Plugin ENABLE_CALCEPH "Optional ephemeris support via CALCEPH (solsys-calceph)")
@@ -99,7 +102,13 @@ if(HAS_MATHLIB)
     string(APPEND PC_LIBS_PRIVATE -l${MATHLIB} " ")
 endif()
 
-check_library_exists(curl curl_init "" HAS_CURL)
+if(NOT WITHOUT_CURL)
+   find_library(curl_FOUND curl REGISTRY_VIEW TARGET REQUIRED)   
+   set(LIBCURL curl)
+   
+   # [.pc] Link applications against curl lib...
+   string(APPEND PC_LIBS_PRIVATE -l${LIBCURL} " ")
+endif()
 
 if(ENABLE_CALCEPH OR ENABLE_CSPICE)
     find_package(Threads)
@@ -128,7 +137,7 @@ endif()
 
 # CSPICE plugin
 if(ENABLE_CSPICE)
-    find_library(cspice cspice REGISTRY_VIEW TARGET REQUIRED)
+    find_library(cspice_FOUND cspice REGISTRY_VIEW TARGET REQUIRED)
     string(APPEND PC_LIBS "-lsolsys-cspice ")
     string(APPEND PC_LIBS_PRIVATE "-lcspice ")
 endif()

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ repository on GitHub, without licensing restrictions. Its source code is compati
 and hence should be suitable for old and new platforms alike. And, despite it being a light-weight library, it fully 
 supports the IAU 2000/2006 conventions for microarcsecond-level position calculations. 
 
-This document has been updated for the `v1.6` and later releases.
+This document has been updated for the `v1.7` and later releases.
 
 
 ## Table of Contents
@@ -224,15 +224,10 @@ accommodate JPL NAIF codes, for which 16-bit storage is insufficient.
 <a name="dependencies"></a>
 ### Dependencies
 
-Required dependencies:
-
- - `libcurl` -- for fetching Earth Orientation data from IERS. (If `libcurl` is not available, and you do not need
-   the EOP ftching functionality, you can disable the dependency by setting `CURL_SUPPORT=0` in your environment prior 
-   to the build.
- 
 Optional dependencies:
 
- - `calceph` -- if building with CALCEPH support enabled.
+ - `libcurl` -- (recommended) for fetching Earth Orientation data from IERS.
+ - `calceph` -- (recommended) if building with CALCEPH support enabled.
  - `cspice` -- if building with CSPICE support enabled.
  - `doxygen` -- if compiling HTML documentation.
  
@@ -416,9 +411,10 @@ The __SuperNOVAS__ CMake build supports the following options (in addition to th
  - `BUILD_SHARED_LIBS=ON|OFF` (default: OFF) - Build shared libraries instead of static
  - `BUILD_DOC=ON|OFF` (default: OFF) - Compile HTML documentation. Requires `doxygen`.
  - `BUILD_EXAMPLES=ON|OFF` (default: OFF) - Build the included examples
- - `BUILD_TESTING=ON|OFF` (default: ON - Build regression tests
- - `BUILD_BENCHMARK=ON|OFF` (default: OFF - Build benchmarking programs 
- - `ENABLE_CPP=ON|OFF` (default: OFF - Build C++11 library (`supernovas++`) also. 
+ - `BUILD_TESTING=ON|OFF` (default: ON) - Build regression tests
+ - `BUILD_BENCHMARK=ON|OFF` (default: OFF) - Build benchmarking programs 
+ - `WITHOUT_CURL=ON|OFF` (default: OFF) - Build without cURL support, which allows fetching EOP from IERS.
+ - `ENABLE_CPP=ON|OFF` (default: OFF) - Build C++11 library (`supernovas++`) also. 
  - `ENABLE_CALCEPH=ON|OFF` (default: OFF) - Optional CALCEPH ephemeris plugin support. Requires `calceph` package.
  - `ENABLE_CSPICE=ON|OFF` (default: OFF) - Optional CSPICE ephemeris plugin support. Requires `cspice` library 
    installed.

--- a/config.mk
+++ b/config.mk
@@ -160,8 +160,13 @@ else
 endif 
 
 ifeq ($(AUTO_DETECT_LIBS),1)
-  # Use ldconfig (if available) to detect CALCEPH / CSPICE shared libs 
+  # Use ldconfig (if available) to detect dependency shared libs 
   # automatically
+  ifndef CURL_SUPPORT
+    ifneq ($(shell ldconfig -p | grep libcurl), )
+      CURL_SUPPORT = 1
+    endif
+  endif
   ifndef CALCEPH_SUPPORT
     ifneq ($(shell ldconfig -p | grep libcalceph), )
       CALCEPH_SUPPORT = 1

--- a/src/c99/CMakeLists.txt
+++ b/src/c99/CMakeLists.txt
@@ -22,9 +22,7 @@ target_include_directories(core PUBLIC
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-if(HAS_CURL)
-  set(LIBCURL curl)
-else()
+if(WITHOUT_CURL)
   target_compile_definitions(core PRIVATE WITHOUT_CURL=1)
 endif()
 

--- a/src/c99/iers.c
+++ b/src/c99/iers.c
@@ -934,6 +934,10 @@ void novas_reset_eop() {
  *     data in some other future ITRF realization, this module may need to be updated, accordingly.
  *     However, the ITRF realization is unlikely to matter significantly.
  *
+ *  8. Prior to 1 Jan 1956, the UT1-UTC time difference is not provided by IERS, as it was not
+ *     measured prior to the age of atomic clocks. Hence for dates prior to 1956 the returned
+ *     EOP will have `dut1`(and its uncertainty) set to NAN.
+ *
  * @param jd              Julian Date (in any timescale, with a preference for UTC)
  * @param timeout_millis  [ms] HTTP connection timeout, or &lt;=0 to leave unchanged.
  * @param[out] eop        Output EOP data structure to populate

--- a/src/c99/timescale.c
+++ b/src/c99/timescale.c
@@ -444,7 +444,8 @@ double get_ut1_to_tt(int leap_seconds, double dut1) {
  *                      the coordinates of an Earth-based observer, you can use
  *                      `novas_itrf_transform_eop()` to make it consistent. If `dut1` is NAN, and
  *                      `novas_is_auto_fetch_eop()` is TRUE then both `leap` and `dut1` will be
- *                      fetched from IERS if possible.
+ *                      fetched from IERS if possible. Note, that prior to 1956 IERS does not
+ *                      provide UT1-UTC difference.
  * @param[out] time     Pointer to the data structure that uniquely defines the astronomical time
  *                      for all applications.
  * @return              0 if successful, or else -1 if there was an error (errno will be set to
@@ -564,7 +565,8 @@ static double tt_offset(const novas_timespec *ts, enum novas_timescale timescale
  *                      the coordinates of an Earth-based observer, you can use
  *                      `novas_itrf_transform_eop()` to make it consistent. If `dut1` is NAN
  *                      and `novas_is_auto_fetch_eop()` is TRUE, then both `leap` and `dut1` will be
- *                      fetched from IERS if possible.
+ *                      fetched from IERS if possible. Note, that prior to 1956 IERS does not
+ *                      provide UT1-UTC difference.
  * @param[out] time     Pointer to the data structure that uniquely defines the astronomical time
  *                      for all applications.
  * @return              0 if successful, or else -1 if there was an error (errno will be set to
@@ -912,7 +914,8 @@ double novas_diff_tcg(const novas_timespec *t1, const novas_timespec *t2) {
  *                    the coordinates of an Earth-based observer, you can use
  *                    `novas_itrf_transform_eop()` to make it consistent. If `dut1` is NAN, and
  *                    `novas_is_auto_fetch_eop()` is TRUE then both `leap` and `dut1` will be
- *                    fetched from IERS if possible.
+ *                    fetched from IERS if possible. Note, that prior to 1956 IERS does not
+ *                      provide UT1-UTC difference.
  * @param[out] time   Pointer to the data structure that uniquely defines the astronomical time
  *                    for all applications.
  * @return            0 if successful, or else -1 if there was an error (errno will be set to

--- a/src/cpp/Calendar.cpp
+++ b/src/cpp/Calendar.cpp
@@ -675,7 +675,8 @@ Time CalendarDate::to_time(int leap_seconds, double dut1, novas_timescale timesc
  * to the same level of precision also.
  *
  * @param eop             (optional) Earth Orientation Parameters (EOP) for this date, or
- *                        EOP::undefined() to fetch from IERS if possible and allowed.
+ *                        EOP::undefined() to fetch from IERS if possible and allowed for dates
+ *                        after 1 Jan 1956.
  * @param timescale       (optional) the astronomical timescale in which this calendar date is
  *                        defined (default: UTC).
  * @return                an astronomical time instance for this date and input parameters.

--- a/src/cpp/Time.cpp
+++ b/src/cpp/Time.cpp
@@ -46,7 +46,8 @@ static bool is_valid_parms(double dUT1,  enum novas_timescale timescale) {
  * @param leap_seconds  [s] leap seconds, that is TAI - UTC (default: 0). It may be unused if
  *                      `dUT1` is NAN -- see below.
  * @param dUT1          [s] UT1 - UTC time difference, e.g. from the IERS Bulletins or service, or
- *                      NAN to fetch leap and dUT1 from IERS, if possible and allowed.
+ *                      NAN to fetch leap and dUT1 from IERS, if possible and allowed for dates
+ *                      after 1 Jan 1956.
  * @param timescale     (optional) Astronomical timescale (default: TT).
  *
  * @since 1.6
@@ -86,7 +87,8 @@ Time::Time(double jd, const EOP& eop, enum novas_timescale timescale)
  * @param leap_seconds  [s] leap seconds, that is TAI - UTC (default: 0). It may be unused if
  *                      `dUT1` is NAN -- see below.
  * @param dUT1          [s] UT1 - UTC time difference, e.g. from the IERS Bulletins or service, or
- *                      NAN to fetch leap and dUT1 from IERS, if possible and allowed.
+ *                      NAN to fetch leap and dUT1 from IERS, if possible and allowed for dates
+ *                      after 1 Jan 1956.
  * @param timescale     (optional) Astronomical timescale (default: TT).
  *
  * @since 1.6
@@ -125,7 +127,8 @@ Time::Time(long ijd, double fjd, const EOP& eop, enum novas_timescale timescale)
  * @param leap_seconds  [s] leap seconds, that is TAI - UTC (default: 0). It may be unused if
  *                      `dUT1` is NAN -- see below.
  * @param dUT1          [s] UT1 - UTC time difference, e.g. from the IERS Bulletins or service, or
- *                      NAN to fetch leap and dUT1 from IERS, if possible and allowed.
+ *                      NAN to fetch leap and dUT1 from IERS, if possible and allowed for dates
+ *                      after 1 Jan 1956.
  * @param timescale     (optional) Astronomical timescale (default: TT).
  *
  * @since 1.6
@@ -166,7 +169,8 @@ Time::Time(const std::string& timestamp, const EOP& eop, enum novas_timescale ti
  * @param leap_seconds  [s] leap seconds, that is TAI - UTC (default: 0). It may be unused if
  *                      `dUT1` is NAN -- see below.
  * @param dUT1          [s] UT1 - UTC time difference, e.g. from the IERS Bulletins or service, or
- *                      NAN to fetch leap and dUT1 from IERS, if possible and allowed.
+ *                      NAN to fetch leap and dUT1 from IERS, if possible and allowed for dates
+ *                      after 1 Jan 1956.
  *
  * @since 1.6
  * @sa now(), from_mjd(), j2000(), b1950(), b1900(), hip()

--- a/test/c99/CMakeLists.txt
+++ b/test/c99/CMakeLists.txt
@@ -44,7 +44,7 @@ foreach(TEST ${TEST_PROGRAMS})
         
         target_compile_definitions(${TEST} PRIVATE RESOURCES="${PROJECT_SOURCE_DIR}/resources")
         
-        if(NOT HAS_CURL)
+        if(WITHOUT_CURL)
             target_compile_definitions(${TEST} PRIVATE WITHOUT_CURL=1)
         endif()
         

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -19,7 +19,7 @@ foreach(TEST ${TEST_PROGRAMS})
               
     target_include_directories(${TEST} PRIVATE ${PROJECT_SOURCE_DIR}/include)
         
-    if(NOT HAS_CURL)
+    if(WITHOUT_CURL)
         target_compile_definitions(${TEST} PRIVATE WITHOUT_CURL=1)
     endif()
 


### PR DESCRIPTION
Various tweaks to Improve CMake and GNU make support for building __SuperNOVAS__ with or without cURL support.