### PR TITLE
Annotate old functions to avoid with deprecated attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,12 @@ Release candidate for the upcoming feature release, possibly around 1 August 202
  
  - Fixed wrong argument types in error traces of `Source` and `Ecliptic` (found by CodeQL).
 
+### Deprecated
+
+ - #323: A few functions, which have already been documented as deprecated, are now annotated as such also so the
+   compiler will warn when these are used. Only the functions, which really should be avoided are affected, either 
+   because they are irrelevant (e.g. `cio_array()`, `cio_basis()`) or prone to misuse (e.g.  `cel2ter()`, `ter2cel()`, 
+   `equ2hor()`), and/or may have unintended consequences (e.g. `cel_pole()`).
  
 
 ## [1.6.0] - 2026-04-27

--- a/include/novas.h
+++ b/include/novas.h
@@ -28,7 +28,7 @@
 #include <time.h>
 
 #ifndef EXTERN
-#  if(WIN32)
+#  if WIN32
 #    define EXTERN __declspec(dllimport) extern
 #  else
 #    define EXTERN extern
@@ -38,6 +38,18 @@
 /// \cond PRIVATE
 #if __STDC_VERSION__ < 199901L
 #  define restrict                        ///< No 'restrict' keyword prior to C99
+#endif
+
+#ifndef COMPAT
+#  define __NOVAS_DEPRECATE__(expl)
+#elif __STDC_VERSION__ >= 202311L || (defined(__cplusplus) && __cplusplus >= 201402L)
+#  define __NOVAS_DEPRECATE__(expl)  [[deprecated(expl)]]
+#elif WIN32
+#  define __NOVAS_DEPRECATE__(expl)  __declspec(deprecated(expl))
+#elif defined(__GNUC__)
+#  define __NOVAS_DEPRECATE__(expl)  __attribute__ ((deprecated))
+#else
+#  define __NOVAS_DEPRECATE__(expl)
 #endif
 /// \endcond
 
@@ -2385,6 +2397,7 @@ typedef double (*RefractionModel)(double jd_tt, const on_surface *loc, enum nova
  * @sa novas_ephem_provider
  *
  */
+__NOVAS_DEPRECATE__("Use get/set_ephem_provider() with a novas_ephem_provider adapter function instead")
 double *readeph(int mp, const char *restrict name, double jd_tdb, int *restrict error);
 #endif
 
@@ -2476,6 +2489,7 @@ short ecl2equ_vec(double jd_tt, enum novas_equator_type coord_sys, enum novas_ac
         const double *in, double *out);
 
 #ifndef _EXCLUDE_DEPRECATED
+__NOVAS_DEPRECATE__("Use tod_to_itrs() or cirs_to_itrs() followed by itrs_to_hor() instead")
 int equ2hor(double jd_ut1, double ut1_to_tt, enum novas_accuracy accuracy, double xp, double yp,
         const on_surface *restrict location, double ra, double dec, enum novas_refraction_model ref_option,
         double *restrict zd, double *restrict az, double *restrict rar, double *restrict decr);
@@ -2495,12 +2509,14 @@ short sidereal_time(double jd_ut1_high, double jd_ut1_low, double ut1_to_tt, enu
 #endif
 
 #ifndef _EXCLUDE_DEPRECATED
+__NOVAS_DEPRECATE__("Use itrs_to_tod() or itrs_to_cirs() instead")
 short ter2cel(double jd_ut1_high, double jd_ut1_low, double ut1_to_tt, enum novas_earth_rotation_measure erot,
         enum novas_accuracy accuracy, enum novas_equatorial_class coordType, double xp, double yp, const double *in,
         double *out);
 #endif
 
 #ifndef _EXCLUDE_DEPRECATED
+__NOVAS_DEPRECATE__("Use tod_to_itrs() or cirs_to_itrs() instead")
 short cel2ter(double jd_ut1_high, double jd_ut1_low, double ut1_to_tt, enum novas_earth_rotation_measure erot,
         enum novas_accuracy accuracy, enum novas_equatorial_class coordType, double xp, double yp, const double *in,
         double *out);
@@ -2533,12 +2549,14 @@ int e_tilt(double jd_tdb, enum novas_accuracy accuracy, double *restrict mobl, d
         double *restrict ee, double *restrict dpsi, double *restrict deps);
 
 #ifndef _EXCLUDE_DEPRECATED
+__NOVAS_DEPRECATE__("Use tod_to_itrs() / itrs_to_tod(), cirs_to_itrs() / itrs_to_cirs(), or novas_make_frame() instead")
 short cel_pole(double jd_tt, enum novas_pole_offset_type type, double dpole1, double dpole2);
 #endif
 
 // in equator.c
 #ifndef _EXCLUDE_DEPRECATED
 /// \cond PRIVATE
+__NOVAS_DEPRECATE__("Meant for internal use only")
 double ee_ct(double jd_tt_high, double jd_tt_low, enum novas_accuracy accuracy);
 /// \endcond
 #endif
@@ -2599,15 +2617,18 @@ int tdb2tt(double jd_tdb, double *restrict jd_tt, double *restrict secdiff);
 short cio_ra(double jd_tt, enum novas_accuracy accuracy, double *restrict ra_cio);
 
 #ifndef _EXCLUDE_DEPRECATED
+__NOVAS_DEPRECATE__("Use cio_ra() or -ira_equinox() instead")
 short cio_location(double jd_tdb, enum novas_accuracy accuracy, double *restrict ra_cio, short *restrict loc_type);
 #endif
 
 #ifndef _EXCLUDE_DEPRECATED
+__NOVAS_DEPRECATE__("Not needed, and actively discouranged")
 short cio_basis(double jd_tdb, double ra_cio, enum novas_cio_location_type loc_type, enum novas_accuracy accuracy,
         double *restrict x, double *restrict y, double *restrict z);
 #endif
 
 #ifndef _EXCLUDE_DEPRECATED
+__NOVAS_DEPRECATE__("Not needed, and actively discouranged")
 short cio_array(double jd_tdb, long n_pts, ra_of_cio *restrict cio);
 #endif
 
@@ -2702,6 +2723,7 @@ int make_ephem_object(const char *name, long num, object *body);
 
 // in cio.c
 #ifndef _EXCLUDE_DEPRECATED
+__NOVAS_DEPRECATE__("Not needed, and actively discouranged")
 int set_cio_locator_file(const char *restrict filename);
 #endif
 
@@ -3657,8 +3679,6 @@ int novas_error(int ret, int en, const char *restrict from, const char *restrict
         } \
 }
 
-
-
 double novas_norm_ang(double angle);
 int novas_time_equals(double jd1, double jd2);
 int novas_time_equals_hp(double jd1, double jd2);
@@ -3684,7 +3704,7 @@ int novas_Rz(double angle, double *v);
 
 int novas_print_decimal(double value, int decimals, char *str, int len);
 
-#if __cplusplus || __STDC_VERSION__ >= 200809L
+#if defined(__cplusplus) || __STDC_VERSION__ >= 200809L
 #  ifndef _POSIX_C_SOURCE
 #    define _POSIX_C_SOURCE 200809L ///< for snprintf
 #  endif
@@ -3698,6 +3718,7 @@ int novas_snprintf(char *buf, size_t len, const char *fmt, ...);
  * @deprecated Use novas_set_max_iter() instead
  * @sa novas_set_max_iter()
  */
+__NOVAS_DEPRECATE__("Use novas_set_max_iter() instead")
 extern int novas_inv_max_iter;
 
 #endif /* __NOVAS_INTERNAL_API__ */

--- a/include/supernovas.h
+++ b/include/supernovas.h
@@ -235,7 +235,7 @@ public:
   static constexpr double GM_sun = NOVAS_G_SUN;	        ///< [m<sup>3</sup> s<sup>-2</sup>] Solar graviational constant
   static constexpr double GM_earth = NOVAS_G_EARTH;     ///< [m<sup>3</sup> s<sup>-2</sup>] Earth graviational constant
   static constexpr double M_sun = GM_sun / G;           ///< [kg] Mass of the Sun
-  static constexpr double M_earth = GM_earth / G;         ///< [kg] Earth mass
+  static constexpr double M_earth = GM_earth / G;       ///< [kg] Earth mass
 
   static constexpr double R_earth = NOVAS_GRS80_RADIUS; ///< [m] 1 Earth quatorial radius (GRS80) in meters
 };
@@ -1216,11 +1216,13 @@ public:
   /// \cond PRIVATE
   // These are the original misspelled forms, which we'll support still, but won't advertise
   // in the documentation.
-  [[deprecated("Use fahrenheit() instead.")]] double farenheit() const {
+  __NOVAS_DEPRECATE__("Use fahrenheit() instead.")
+  double farenheit() const {
     return fahrenheit();
   }
 
-  [[deprecated("Use fahrenheit(double) instead.")]] static Temperature farenheit(double value) {
+  __NOVAS_DEPRECATE__("Use fahrenheit(double) instead.")
+  static Temperature farenheit(double value) {
     return fahrenheit(value);
   }
   /// \endcond

--- a/legacy/solarsystem.h
+++ b/legacy/solarsystem.h
@@ -15,6 +15,7 @@
 #endif
 /// \endcond
 
+
 #ifndef _EXCLUDE_DEPRECATED
 /**
  * @deprecated (legacy function</i>) Use `set_planet_provider()` instead to specify what

--- a/src/c99/CMakeLists.txt
+++ b/src/c99/CMakeLists.txt
@@ -26,6 +26,9 @@ if(WITHOUT_CURL)
   target_compile_definitions(core PRIVATE WITHOUT_CURL=1)
 endif()
 
+# Allow deprecated functions internally
+set(CMAKE_WARN_DEPRECATED FALSE)
+
 # Link with math libs as necessary
 target_link_libraries(core PUBLIC ${MATHLIB} ${LIBCURL})
 

--- a/src/c99/Makefile
+++ b/src/c99/Makefile
@@ -17,6 +17,9 @@ LIB ?= ../../lib
 # Our own include directory
 CPPFLAGS += -I../../include
 
+# Allow deprecated functions to be used interally
+CFLAGS += -Wno-deprecated-declarations
+
 # We'll need math functions to link
 LDFLAGS += -lm
 

--- a/test/c99/CMakeLists.txt
+++ b/test/c99/CMakeLists.txt
@@ -22,6 +22,9 @@ if(ENABLE_CSPICE)
     list(APPEND TEST_PROGRAMS test-cspice)
 endif()
 
+# Allow deprecated functions internally
+set(CMAKE_WARN_DEPRECATED FALSE)
+
 # Directory where ephemeris data for the tests are found
 set(EPHEM_DIR ${PROJECT_SOURCE_DIR}/test/ephem)
 

--- a/test/c99/Makefile
+++ b/test/c99/Makefile
@@ -9,8 +9,11 @@ include ../../config.mk
 # Flags for measuring test coverage
 # Our own include directory
 CPPFLAGS += -I../../include
-CFLAGS += -I../../include -I../../legacy -pg -Wall
+CFLAGS += -I../../include -I../../legacy -pg -Wall 
 LDFLAGS += -lm -lcurl -fprofile-arcs -ftest-coverage
+
+# Allow deprecated functions to be used interally
+CFLAGS += -Wno-deprecated-declarations
 
 # cppcheck options for 'check' target. You can add additional options by
 # setting the CHECKEXTRA variable (e.g. in shell) prior to invoking 'make'.


### PR DESCRIPTION
While the Doxygen documentation mentions which old NOVAS C functions have been deprecated, there are a few functions that should be more actively discouraged. Adding annotations for these deprecated functions will result in compiler warnings to bring attention to the more questionable bits of the old API.