### PR TITLE
Reduce libc surface for embedded/bare metal targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ Release candidate for the upcoming feature release, possibly around 1 August 202
    
  - #319: Consolidated local portable mutex definitions in `novas-mutex.h` (not installed).
 
+ - New `novas_set_error_handler()` (and `novas_error_handler` typedef) to route `novas_trace()` / `novas_error()`
+   output through a user-supplied callback instead of `fprintf(stderr, ...)`. Pass NULL to silence.
+
+ - New `NOVAS_NO_SYSTEM_CLOCK` build flag compiles out `novas_set_current_time()` for targets without a
+   real-time clock (e.g. embedded, freestanding).
+
 ### Changed
 
  - #313: `novas_set_time()` and related similar functions, can now fetch leap seconds and the mean interpolated 

--- a/include/novas.h
+++ b/include/novas.h
@@ -22,6 +22,7 @@
 #define _NOVAS_
 
 #include <math.h>   // for sin, cos
+#include <stdarg.h> // va_list (for novas_error_handler)
 #include <stdio.h>  // FILE
 #include <stdlib.h> // NULL
 #include <stdint.h>
@@ -2699,6 +2700,38 @@ void novas_debug(enum novas_debug_mode mode);
 
 /// @ingroup util
 enum novas_debug_mode novas_get_debug_mode();
+
+/**
+ * Callback type for the trace / error message handler.
+ *
+ * Invoked from the internal tracing helpers (`novas_trace()`,
+ * `novas_set_errno()`, `novas_error()`, etc.) whenever the debug mode is not
+ * `NOVAS_DEBUG_OFF`. The default handler writes to `stderr` via `vfprintf()`.
+ *
+ * Replacing the handler lets embedded, WASM, or otherwise freestanding
+ * targets redirect error output (or silence it entirely) without paying the
+ * cost of `stderr`.
+ *
+ * @param fmt   `printf`-style format string, never NULL
+ * @param args  variadic argument list matching `fmt`
+ *
+ * @since 1.7
+ * @sa novas_set_error_handler()
+ */
+typedef void (*novas_error_handler)(const char *fmt, va_list args);
+
+/**
+ * Replaces the trace / error message handler. Pass NULL to silence error
+ * output entirely while keeping `errno` and return-code propagation intact.
+ *
+ * @param handler  new handler, or NULL to disable error output
+ * @return         the previous handler (so it can be restored or chained)
+ *
+ * @since 1.7
+ * @sa novas_error_handler
+ * @ingroup util
+ */
+novas_error_handler novas_set_error_handler(novas_error_handler handler);
 
 /// @c_util
 double novas_norm_ang(double angle);

--- a/src/c99/timescale.c
+++ b/src/c99/timescale.c
@@ -982,16 +982,25 @@ int novas_set_unix_time(time_t unix_time, long nanos, int leap, double dut1, nov
  * @sa novas_set_auto_fetch_eop(), novas_lookup_leap(), novas_fetch_eop()
  */
 int novas_set_current_time(int leap, double dut1, novas_timespec *restrict time) {
+#ifdef NOVAS_NO_SYSTEM_CLOCK
+  (void) leap;
+  (void) dut1;
+  (void) time;
+  return novas_error(-1, ENOSYS, "novas_set_current_time",
+          "system clock support disabled at build time (NOVAS_NO_SYSTEM_CLOCK); "
+          "use novas_set_unix_time() with an externally-supplied time instead");
+#else
   struct timespec t = {};
 
-#if (__STDC_VERSION__ >= 201112L && !defined(__ANDROID__)) || defined(_MSC_VER)
+#  if (__STDC_VERSION__ >= 201112L && !defined(__ANDROID__)) || defined(_MSC_VER)
   timespec_get(&t, TIME_UTC);
-#else
+#  else
   clock_gettime(CLOCK_REALTIME, &t);
-#endif
+#  endif
 
   prop_error("novas_set_current_time", novas_set_unix_time(t.tv_sec, t.tv_nsec, leap, dut1, time), 0);
   return 0;
+#endif
 }
 
 /**

--- a/src/c99/util.c
+++ b/src/c99/util.c
@@ -25,6 +25,36 @@
 /// Current debugging state for reporting errors and traces to stderr.
 static enum novas_debug_mode novas_debug_state = NOVAS_DEBUG_OFF;
 
+/// Default error handler: writes the formatted message to stderr.
+static void default_error_handler(const char *fmt, va_list args) {
+  vfprintf(stderr, fmt, args);
+}
+
+/// Active error handler. NULL means "silenced".
+static novas_error_handler novas_error_handler_fn = default_error_handler;
+
+/**
+ * Replaces the trace / error message handler. See novas.h for the public
+ * docs.
+ */
+novas_error_handler novas_set_error_handler(novas_error_handler handler) {
+  novas_error_handler prev = novas_error_handler_fn;
+  novas_error_handler_fn = handler;
+  return prev;
+}
+
+/// (_internal_) Emit a trace message through the active handler.
+static void novas_emit(const char *fmt, ...) {
+  if(!novas_error_handler_fn)
+    return;
+  {
+    va_list args;
+    va_start(args, fmt);
+    novas_error_handler_fn(fmt, args);
+    va_end(args);
+  }
+}
+
 /**
  * Maximum number of iterations for convergent inverse calculations. Most iterative inverse
  * functions should normally converge in a handful of iterations. In some pathological cases more
@@ -70,7 +100,7 @@ int novas_trace(const char *restrict loc, int n, int offset) {
   if(n != 0) {
     n = n < 0 ? -1 : n + offset;
     if(novas_get_debug_mode() != NOVAS_DEBUG_OFF)
-      fprintf(stderr, "       @ %s [=> %d]\n", loc, n);
+      novas_emit("       @ %s [=> %d]\n", loc, n);
   }
   return n;
 }
@@ -86,7 +116,7 @@ int novas_trace(const char *restrict loc, int n, int offset) {
  */
 double novas_trace_nan(const char *restrict loc) {
   if(novas_get_debug_mode() != NOVAS_DEBUG_OFF) {
-    fprintf(stderr, "       @ %s [=> NAN]\n", loc);
+    novas_emit("       @ %s [=> NAN]\n", loc);
   }
   return NAN;
 }
@@ -101,7 +131,7 @@ double novas_trace_nan(const char *restrict loc) {
  */
 void novas_trace_invalid(const char *restrict loc) {
   if(novas_get_debug_mode() != NOVAS_DEBUG_OFF) {
-    fprintf(stderr, "       @ %s [=> invalid]\n", loc);
+    novas_emit("       @ %s [=> invalid]\n", loc);
   }
 }
 
@@ -141,10 +171,10 @@ void novas_set_errno(int en, const char *restrict from, const char *restrict des
   va_list varg;
 
   va_start(varg, desc);
-  if(novas_get_debug_mode() != NOVAS_DEBUG_OFF) {
-    fprintf(stderr, "\n  ERROR! %s: ", from);
-    vfprintf(stderr, desc, varg);
-    fprintf(stderr, "\n");
+  if(novas_get_debug_mode() != NOVAS_DEBUG_OFF && novas_error_handler_fn) {
+    novas_emit("\n  ERROR! %s: ", from);
+    novas_error_handler_fn(desc, varg);
+    novas_emit("\n");
   }
   va_end(varg);
 
@@ -169,10 +199,10 @@ int novas_error(int ret, int en, const char *restrict from, const char *restrict
   va_list varg;
 
   va_start(varg, desc);
-  if(novas_get_debug_mode() != NOVAS_DEBUG_OFF) {
-    fprintf(stderr, "\n  ERROR! %s: ", from);
-    vfprintf(stderr, desc, varg);
-    fprintf(stderr, " [=> %d]\n", ret);
+  if(novas_get_debug_mode() != NOVAS_DEBUG_OFF && novas_error_handler_fn) {
+    novas_emit("\n  ERROR! %s: ", from);
+    novas_error_handler_fn(desc, varg);
+    novas_emit(" [=> %d]\n", ret);
   }
   va_end(varg);
 

--- a/test/c99/test-errors.c
+++ b/test/c99/test-errors.c
@@ -3,6 +3,7 @@
  * @author Attila Kovacs
  */
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -2610,6 +2611,111 @@ static int test_trace_invalid() {
   return n;
 }
 
+// Capturing handler used by test_error_handler() below. Appends to the buffer
+// because some emission paths (novas_set_errno, novas_error) invoke the handler
+// multiple times per call (prefix + body + suffix).
+static char captured_msg[512];
+static int captured_len = 0;
+
+static void capturing_handler(const char *fmt, va_list args) {
+  int avail = (int) sizeof(captured_msg) - captured_len;
+  if(avail > 1) {
+    int n = vsnprintf(captured_msg + captured_len, (size_t) avail, fmt, args);
+    if(n > 0) captured_len += (n < avail) ? n : (avail - 1);
+  }
+}
+
+static void reset_captured(void) {
+  captured_msg[0] = '\0';
+  captured_len = 0;
+}
+
+static int test_error_handler() {
+  int n = 0;
+  enum novas_debug_mode mode = novas_get_debug_mode();
+  novas_error_handler default_h;
+  novas_error_handler prev;
+
+  // Installing a custom handler returns the previous (default) handler.
+  default_h = novas_set_error_handler(capturing_handler);
+  if(!default_h) {
+    fprintf(stderr, "ERROR! novas_set_error_handler should return non-NULL default handler\n");
+    n++;
+  }
+
+  novas_debug(NOVAS_DEBUG_ON);
+
+  // novas_trace() routes through the active handler.
+  reset_captured();
+  (void) novas_trace("test_error_handler:trace", 1, 10);
+  if(!strstr(captured_msg, "test_error_handler:trace")) {
+    fprintf(stderr, "ERROR! novas_trace not routed: %s\n", captured_msg);
+    n++;
+  }
+
+  // novas_trace_nan() / novas_trace_invalid() also go through the handler.
+  reset_captured();
+  (void) novas_trace_nan("test_error_handler:nan");
+  if(!strstr(captured_msg, "test_error_handler:nan")) {
+    fprintf(stderr, "ERROR! novas_trace_nan not routed: %s\n", captured_msg);
+    n++;
+  }
+  reset_captured();
+  novas_trace_invalid("test_error_handler:invalid");
+  if(!strstr(captured_msg, "test_error_handler:invalid")) {
+    fprintf(stderr, "ERROR! novas_trace_invalid not routed: %s\n", captured_msg);
+    n++;
+  }
+
+  // Variadic paths: novas_set_errno() and novas_error() forward va_list to handler.
+  reset_captured();
+  novas_set_errno(EINVAL, "test_error_handler", "errno value %d", 42);
+  if(!strstr(captured_msg, "42")) {
+    fprintf(stderr, "ERROR! novas_set_errno not routed: %s\n", captured_msg);
+    n++;
+  }
+  reset_captured();
+  (void) novas_error(-1, EINVAL, "test_error_handler", "err %s", "abc");
+  if(!strstr(captured_msg, "abc")) {
+    fprintf(stderr, "ERROR! novas_error not routed: %s\n", captured_msg);
+    n++;
+  }
+
+  // NULL handler silences output across all paths.
+  novas_set_error_handler(NULL);
+  reset_captured();
+  (void) novas_trace("test_error_handler:silenced", 1, 0);
+  (void) novas_trace_nan("test_error_handler:silenced");
+  novas_trace_invalid("test_error_handler:silenced");
+  novas_set_errno(EINVAL, "test_error_handler", "silenced %d", 1);
+  (void) novas_error(-1, EINVAL, "test_error_handler", "silenced %s", "msg");
+  if(captured_msg[0] != '\0') {
+    fprintf(stderr, "ERROR! NULL handler did not silence: %s\n", captured_msg);
+    n++;
+  }
+
+  // Replacing NULL with a real handler reports NULL as the previous.
+  prev = novas_set_error_handler(capturing_handler);
+  if(prev != NULL) {
+    fprintf(stderr, "ERROR! expected NULL as previous handler, got non-NULL\n");
+    n++;
+  }
+
+  // errno propagation is independent of the handler.
+  errno = 0;
+  (void) novas_error(-1, ERANGE, "test_error_handler", "%s", "x");
+  if(errno != ERANGE) {
+    fprintf(stderr, "ERROR! novas_error did not set errno through custom handler\n");
+    n++;
+  }
+
+  // Restore so the rest of the suite uses the default handler.
+  novas_set_error_handler(default_h);
+  novas_debug(mode);
+
+  return n;
+}
+
 static int test_check_nan() {
   int n = 0;
 
@@ -3145,6 +3251,7 @@ int main(int argc, const char *argv[]) {
   if(test_time_leap()) n++;
 
   if(test_trace_invalid()) n++;
+  if(test_error_handler()) n++;
   if(test_check_nan()) n++;
 
   if(test_moon_elp_ecl_pos()) n++;

--- a/test/c99/test-super.c
+++ b/test/c99/test-super.c
@@ -2192,14 +2192,22 @@ static int test_unix_time() {
 }
 
 static int test_set_current_time() {
+#ifdef NOVAS_NO_SYSTEM_CLOCK
+  novas_timespec t = {};
+  // With the system clock disabled, novas_set_current_time() must return -1
+  // with errno set to ENOSYS, and must not touch the output.
+  if(novas_set_current_time(37, 0.014, &t) != -1) return 1;
+  if(errno != ENOSYS) return 1;
+  return 0;
+#else
   struct timespec now = {};
   novas_timespec t1 = {}, t2 = {};
 
-#if (__STDC_VERSION__ >= 201112L && !defined(__ANDROID__)) || defined(_MSC_VER)
+#  if (__STDC_VERSION__ >= 201112L && !defined(__ANDROID__)) || defined(_MSC_VER)
   timespec_get(&now, TIME_UTC);
-#else
+#  else
   clock_gettime(CLOCK_REALTIME, &now);
-#endif
+#  endif
 
   novas_set_current_time(37, 0.014, &t1);
 
@@ -2207,6 +2215,7 @@ static int test_set_current_time() {
 
   if(!is_equal("set_current_time:diff", 0.0, novas_diff_time(&t1, &t2), 1e-3)) return 1;
   return 0;
+#endif
 }
 
 static int test_set_str_time() {


### PR DESCRIPTION
## Motivation

I'm working on a safe Rust wrapper for SuperNOVAS and realized that we're quite close to having a library that would work on resource-constrained targets. This is potentially useful as this could enable SuperNOVAS on microcontrollers (maybe simple antenna drive electronics) or web-based analysis tools with WASM. Looking through the code base, there really is not that much that needs the C runtime or an allocator (which is the limiting factor for these targets). While this PR isn't everything (there are still calls to errno and snprintf, in which removal would enable true bare-metal support), this should get us most of the way there for another PR.

## Changes

1. `timescale.c`: `NOVAS_NO_SYSTEM_CLOCK` build flag

`novas_set_current_time` is the only function in the C99 core that needs system time information. On targets with no clock, this change allows users to build with `-DNOVAS_NO_SYSTEM_CLOCK`. Then, this function returns -1 with an error and descriptions. However, on bare-metal targets we then can avoid use of `novas_set_current_time` and not get linker errors!

The default behavior is of course unchanged.

2. `util.c`: pluggable trace/error message handler

This is perhaps the biggest change. Currently, the debug/trace handling always uses stdio for its output. On other bare-metal platforms, there is either some hook for stdio (which we don't want to use), or some way to get IO. I'm thinking mainly on embedded, there are nice out-of-band logging frameworks that would be really nice to hook in here.

As such, I've replaced the fprintf calls in the five tracing helpers with a function-pointer hook.
This introduces a new public API:

```c
 typedef void (*novas_error_handler)(const char *fmt, va_list args);
  novas_error_handler novas_set_error_handler(novas_error_handler handler);
```

So:
  - Default handler calls vfprintf(stderr, fmt, args) which is identical to current behavior
  - Passing NULL silences output entirely while keeping errno and return-code propagation intact
  - Users can redirect output to UART, ITM, an in-memory ring buffer, or syslog, anywhere relevant for their target

## Future Work

For full bare-metal support we need to remove the snprintf calls and errno writes, but that was a bit more work and I thought we'd start with this. Already with this PR we should be able to run on some WASM platforms.