### PR TITLE
timescale.c: fix fractional precision loss in novas_set_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Release candidate for the upcoming feature release, possibly around 1 August 202
    
  - #324: Fixed definition of `NOVAS_MARS_INIT` (it had the number ID of Mercury).
 
+ - Fixed `novas_set_time()` always passing the fractional JD as the full Julian date, losing ~1 &mu;s of 
+   fractional precision in the stored `fjd_tt` field due to the large+small addition in IEEE 754 double.
+   Now splits the JD into integer and fractional parts before calling `novas_set_split_time()`, matching
+   the existing pattern in `novas_set_unix_time()`.
+
 ### Added
 
  - #313: Support for fetching of leap-seconds and EOP data from IERS, also automatically as needed when the EOP 

--- a/src/c99/timescale.c
+++ b/src/c99/timescale.c
@@ -460,7 +460,8 @@ double get_ut1_to_tt(int leap_seconds, double dut1) {
  * @sa novas_set_auto_fetch_eop(), novas_lookup_leap(), novas_fetch_eop()
  */
 int novas_set_time(enum novas_timescale timescale, double jd, int leap, double dut1, novas_timespec *restrict time) {
-  prop_error("novas_set_time", novas_set_split_time(timescale, 0, jd, leap, dut1, time), 0);
+  long ijd = (long) floor(jd);
+  prop_error("novas_set_time", novas_set_split_time(timescale, ijd, jd - ijd, leap, dut1, time), 0);
   return 0;
 }
 

--- a/test/c99/test-super.c
+++ b/test/c99/test-super.c
@@ -1325,6 +1325,16 @@ static int test_set_time() {
     return 1;
   }
 
+  {
+    // Regression: novas_set_time used to lose ~1 µs of fractional precision
+    // by passing the entire JD as fjd with ijd=0, causing large+small
+    // addition in IEEE 754 double. Verify fjd_tt matches the split path.
+    novas_timespec ref;
+    if(!is_ok("set_time:precision:set:ref", novas_set_split_time(NOVAS_UTC, (long)J2000, 0.0, leap, 0.0, &ref))) return 1;
+    if(!is_ok("set_time:precision:set:test", novas_set_time(NOVAS_UTC, J2000, leap, 0.0, &tt1))) return 1;
+    if(!is_equal("set_time:precision:fjd", tt1.fjd_tt, ref.fjd_tt, 1e-15)) return 1;
+  }
+
   if(!is_ok("set_time:set:tdb", novas_set_split_time(NOVAS_TDB, ijd, fjd, leap, dut1, &TDB))) return 1;
   if(!is_ok("set_time:set:tcb", novas_set_split_time(NOVAS_TCB, ijd, fjd, leap, dut1, &tcb))) return 1;
   if(!is_ok("set_time:set:tcg", novas_set_split_time(NOVAS_TCG, ijd, fjd, leap, dut1, &tcg))) return 1;


### PR DESCRIPTION
`novas_set_time` passed the entire JD as fjd with ijd=0, causing novas_set_split_time to compute fjd = large_JDN - offset/DAY. Adding a tiny fraction (~0.001) to a large integer (~2.4M) in IEEE 754 double loses ~32 bits of fractional mantissa, corrupting `fjd_tt` at the microsecond level.

Fix by splitting the JD into integer and fractional parts before calling `novas_set_split_time`, matching the pattern already used by `novas_set_unix_time`. This ensures the timescale offset arithmetic is done on small numbers only, preserving full fractional precision.