### PR TITLE
Bare metal support with NOVAS_NO_LIBC flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,3 +144,18 @@ jobs:
             export LDFLAGS=`pkg-config --libs libcurl`
             gmake static
             gmake shared
+
+  build-mcu:
+    runs-on: ubuntu-latest
+    name: Embedded ARM
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: carlosperate/arm-none-eabi-gcc-action@v1
+
+      - name: Build static library (bare-metal, no-libc)
+        # As an example, compile a static library for the RP2350 microcontroller
+        run: >
+          make CC=arm-none-eabi-gcc WITHOUT_LIBC=1
+          CFLAGS="-mcpu=cortex-m33 -mthumb -mfloat-abi=hard -mfpu=fpv5-sp-d16 -Os -Wall -Werror"
+          static

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ Release candidate for the upcoming feature release, possibly around 1 August 202
    targets without real-time clock (e.g. embedded, freestanding). If set during the build, `novas_set_current_time()` 
    will simply return an error. (by @kiranshila)
 
+ - `WITHOUT_LIBC=1` build mode for freestanding targets (bare-metal, WebAssembly) with no libc file I/O, heap, or
+   system clock. Automatically sets `NOVAS_NO_LIBC=1` and `NOVAS_NO_SYSTEM_CLOCK=1`, and forces `CURL_SUPPORT=0`.
+   CI now cross-compiles and verifies the static library for ARM Cortex-M33.
 ### Changed
 
  - #313: `novas_set_time()` and related similar functions, can now fetch leap seconds and the mean interpolated 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,15 @@ option(ENABLE_CPP "Enable C++ library build (supernovas++ library)" OFF)
 option(ENABLE_CALCEPH "Enable CALCEPH support (solsys-calceph plugin)" OFF)
 option(ENABLE_CSPICE "Enable CSPICE support (solsys-cspice plugin)" OFF)
 option(ENABLE_TESTING_ONLINE "Run online tests requiring internet access" OFF)
+option(WITHOUT_LIBC "Build without libc-dependent features (file I/O, heap, system clock). Enable for bare-metal/WASM targets." OFF)
+
+if(WITHOUT_LIBC)
+    set(WITHOUT_CURL ON CACHE BOOL "Forced ON: WITHOUT_LIBC=ON" FORCE)
+    set(ENABLE_CPP OFF CACHE BOOL "Forced OFF: WITHOUT_LIBC=ON" FORCE)
+    set(ENABLE_CALCEPH OFF CACHE BOOL "Forced OFF: WITHOUT_LIBC=ON" FORCE)
+    set(ENABLE_CSPICE OFF CACHE BOOL "Forced OFF: WITHOUT_LIBC=ON" FORCE)
+    message(STATUS "WITHOUT_LIBC=ON: forcing WITHOUT_CURL=ON, ENABLE_CPP/CALCEPH/CSPICE=OFF")
+endif()
 
 # Set feature descriptions for summary
 add_feature_info(SharedLibs BUILD_SHARED_LIBS "Build as shared libraries")
@@ -54,6 +63,7 @@ add_feature_info(Examples BUILD_EXAMPLES "Build and test example programs")
 add_feature_info(Benchmarks BUILD_BENCHMARK "Build benchmarking programs")
 
 add_feature_info(Without-cURL WITHOUT_CURL "Build with cURL support (no fetching EOP from IERS possible)")
+add_feature_info(Without-libc WITHOUT_LIBC "Build without libc-dependent features (file I/O, heap, system clock)")
 
 add_feature_info(C++-Libs ENABLE_CPP "Build C++ library also (supernovas++)")
 add_feature_info(Calceph-Plugin ENABLE_CALCEPH "Optional ephemeris support via CALCEPH (solsys-calceph)")

--- a/README.md
+++ b/README.md
@@ -324,6 +324,11 @@ Additionally, you may set number of environment variables to futher customize th
  
  - `CURL_SUPPORT`: Setting to 0 disables building against `libcurl` (default: 1). If disabled, the EOP fetching 
    functions and methods will return an error or invalid EOP, with `errno` set to `ENOSYS`.
+
+ - `WITHOUT_LIBC`: Setting to 1 builds the library for bare-metal or WebAssembly targets
+   that have no libc file I/O, heap allocator, or system clock. This sets the `NOVAS_NO_LIBC` and 
+   `NOVAS_NO_SYSTEM_CLOCK` preprocessor flags, and forces `CURL_SUPPORT=0`. See the 
+   [Cross-compiling for embedded targets](#cross-compile) section below.
  
  - `DOXYGEN`: Specify the `doxygen` executable to use for generating documentation. If not set (default), `make` will
    use `doxygen` in your `PATH` (if any). You can also set it to `none` to disable document generation and the
@@ -389,6 +394,36 @@ Now you can build __SuperNOVAS__, for example as a shared library, with:
 
 ```bash
   gmake shared
+```
+
+</details>
+
+
+<a name="cross-compile"></a>
+#### Cross-compiling for embedded targets
+
+<details>
+
+__SuperNOVAS__ can be compiled as a static library for bare-metal embedded systems (e.g. ARM Cortex-M) or WebAssembly
+targets. Set `WITHOUT_LIBC=1` to build in freestanding mode, which disables all libc file I/O, heap allocation, and
+system clock dependencies:
+
+
+For embedded ARM, this may look like:
+
+```bash
+  make CC=arm-none-eabi-gcc WITHOUT_LIBC=1 \
+       CFLAGS="-mcpu=cortex-m33 -mthumb -mfloat-abi=hard -mfpu=fpv5-sp-d16 -Os -Wall" \
+       static
+```
+
+where we cross-compile using the arm-none-eabi-gcc compiler with target-specific flags.
+
+For WebAssembly with [Emscripten](https://emscripten.org/), use `emmake` which substitutes the compiler and archiver
+automatically:
+
+```bash
+  emmake make WITHOUT_LIBC=1 static
 ```
 
 </details>

--- a/config.mk
+++ b/config.mk
@@ -69,6 +69,12 @@ CFLAGS ?= -g -Os -Wall
 CURL_SUPPORT = 1
 
 
+# Set to 1 to build for freestanding targets (bare-metal, WASM) that have no
+# libc file I/O, heap, or system clock. Forces CURL_SUPPORT=0.
+# The C preprocessor flag NOVAS_NO_LIBC=1 is defined automatically.
+#WITHOUT_LIBC = 1
+
+
 # cppcheck options for 'check' target. You can add additional options by
 # setting the CHECKEXTRA variable (e.g. in shell) prior to invoking 'make'.
 LANGUAGE ?= c

--- a/src/c99/CMakeLists.txt
+++ b/src/c99/CMakeLists.txt
@@ -26,6 +26,10 @@ if(WITHOUT_CURL)
   target_compile_definitions(core PRIVATE WITHOUT_CURL=1)
 endif()
 
+if(WITHOUT_LIBC)
+  target_compile_definitions(core PRIVATE NOVAS_NO_LIBC=1 NOVAS_NO_SYSTEM_CLOCK=1)
+endif()
+
 # Allow deprecated functions internally
 set(CMAKE_WARN_DEPRECATED FALSE)
 

--- a/src/c99/Makefile
+++ b/src/c99/Makefile
@@ -38,6 +38,14 @@ ifeq ($(CSPICE_SUPPORT), 1)
   SHARED_TARGETS += $(LIB)/libsolsys-cspice.$(SOEXT)
 endif
 
+ifeq ($(WITHOUT_LIBC), 1)
+  CPPFLAGS += -DNOVAS_NO_LIBC=1 -DNOVAS_NO_SYSTEM_CLOCK=1
+  override CURL_SUPPORT := 0
+  override CALCEPH_SUPPORT :=
+  override CSPICE_SUPPORT :=
+  override ENABLE_CPP :=
+endif
+
 ifeq ($(CURL_SUPPORT), 0)
   CPPFLAGS += -DWITHOUT_CURL=1
 else

--- a/src/c99/frames.c
+++ b/src/c99/frames.c
@@ -97,7 +97,6 @@
  * @sa timescale.c, observer.c, target.c, ephemeris.c
  */
 
-#include <stdlib.h>
 #include <string.h>
 #include <errno.h>
 #include <math.h>

--- a/src/c99/iers.c
+++ b/src/c99/iers.c
@@ -16,19 +16,20 @@
  *  @sa \ref earth
  */
 
-#if !defined(_MSC_VER)
+#if !defined(_MSC_VER) && !defined(NOVAS_NO_LIBC)
 #  define _GNU_SOURCE               ///< fmemopen (before glibc 2.10)
 #endif
 
-
-#include <stdio.h>
-#include <stdlib.h>   // atexit()
+#include <errno.h>
 #include <string.h>
 #include <time.h>
-#include <errno.h>
 
-#if !WITHOUT_CURL
-#include <curl/curl.h>
+#ifndef NOVAS_NO_LIBC
+#  include <stdio.h>
+#  include <stdlib.h>   // atexit(), calloc(), free()
+#  if !WITHOUT_CURL
+#    include <curl/curl.h>
+#  endif
 #endif
 
 /// \cond PRIVATE
@@ -36,7 +37,10 @@
 /// \endcond
 
 #include "novas.h"
+
+#ifndef NOVAS_NO_LIBC
 #include "novas-mutex.h"
+#endif
 
 /// \cond PRIVATE
 
@@ -71,10 +75,12 @@ typedef struct iers_leap_entry {
 
 /// \endcond
 
+#ifndef NOVAS_NO_LIBC
 static iers_leap_entry *leaps;      ///< Leap seconds list
 static time_t leap_expiration;      ///< UNIX time at which leap seconds list expires.
 static lock_type leap_mutex;        ///< mutex for leap seconds data
 static int leap_mutex_initialized;  ///< whether the leap mutex was initialized;
+#endif
 
 
 // ---------------------------------------------------------------------------
@@ -159,6 +165,8 @@ static int eop_mutex_initialized;  ///< Whether EOP mutex was initialized
 /// \endcond
 #endif /* !WITHOUT_CURL */
 // ---------------------------------------------------------------------------
+
+#ifndef NOVAS_NO_LIBC
 
 static void lock_leap() {
   if(!leap_mutex_initialized) {
@@ -251,6 +259,7 @@ static iers_leap_entry *parse_leap_file(FILE *fp, long long *expiration) {
   return list;
 }
 
+#endif /* !NOVAS_NO_LIBC */
 // ---------------------------------------------------------------------------
 #if !WITHOUT_CURL
 
@@ -624,6 +633,10 @@ static void cleanup_eop_urls_async() {
 int novas_set_leap_list(const char *filename) {
   static const char *fn = "novas_set_leap_list";
 
+#ifdef NOVAS_NO_LIBC
+  (void) filename;
+  return novas_error(-1, ENOSYS, fn, "built with NOVAS_NO_LIBC: file I/O unavailable");
+#else
   FILE *fp;
   iers_leap_entry *list;
   long long expiration = 0LL;
@@ -651,6 +664,7 @@ int novas_set_leap_list(const char *filename) {
   novas_unlock(&leap_mutex);
 
   return 0;
+#endif /* !NOVAS_NO_LIBC */
 }
 
 /**
@@ -676,6 +690,10 @@ int novas_set_leap_list(const char *filename) {
 int novas_lookup_leap(time_t t) {
   static const char *fn = "novas_lookup_leap";
 
+#ifdef NOVAS_NO_LIBC
+  (void) t;
+  return novas_error(NOVAS_INVALID_LEAP, ENOSYS, fn, "built with NOVAS_NO_LIBC: supply leap count explicitly");
+#else
   const iers_leap_entry *e;
   char str[40] = {'\0'};
 
@@ -716,6 +734,7 @@ int novas_lookup_leap(time_t t) {
   unlock_leap();
 
   return 0;
+#endif /* !NOVAS_NO_LIBC */
 }
 
 
@@ -895,16 +914,18 @@ int novas_get_eop_itrf_year(enum novas_eop_series series) {
  * @sa novas_set_leap_list(), novas_fetch_eop()
  */
 void novas_reset_eop() {
+#ifndef NOVAS_NO_LIBC
  lock_leap();
  set_leap_list_async(NULL, 0LL);
  unlock_leap();
 
-#if !WITHOUT_CURL
+#  if !WITHOUT_CURL
  lock_eop();
  cleanup_eop_urls_async();
  cleanup_eop_handles_async();
  unlock_eop();
-#endif
+#  endif
+#endif /* !NOVAS_NO_LIBC */
 }
 
 /**

--- a/src/c99/itrf.c
+++ b/src/c99/itrf.c
@@ -16,7 +16,6 @@
  * @sa observer.c
  */
 
-#include <stdlib.h>
 #include <string.h>
 #include <errno.h>
 

--- a/src/c99/parse.c
+++ b/src/c99/parse.c
@@ -90,11 +90,11 @@ double novas_epoch(const char *restrict system) {
   if(strcasecmp(system, NOVAS_SYSTEM_HIP) == 0)
     return NOVAS_JD_HIP;
 
-  if(toupper(system[0]) == 'B') {
+  if(toupper((unsigned char)system[0]) == 'B') {
     type = 'B';
     system++;
   }
-  else if(toupper(system[0]) == 'J') {
+  else if(toupper((unsigned char)system[0]) == 'J') {
     type = 'J';
     system++;
   }
@@ -191,7 +191,7 @@ double novas_parse_hms(const char *restrict hms, char **restrict tail) {
 
   // The trailing markers must be standalone (end of string or followed by white space)
   next = hms[n + k];
-  if(next == '\0' || next == '_' || isspace(next) || ispunct(next))
+  if(next == '\0' || next == '_' || isspace((unsigned char)next) || ispunct((unsigned char)next))
     n += k;
 
   if(tail)
@@ -252,7 +252,7 @@ double novas_hms_hours(const char *restrict hms) {
   errno = 0;
 
   // Skip trailing white spaces / punctuation
-  while(*tail && (isspace(*tail) || ispunct(*tail))) tail++;
+  while(*tail && (isspace((unsigned char)*tail) || ispunct((unsigned char)*tail))) tail++;
   if(*tail)
     errno = EINVAL;
 
@@ -266,14 +266,14 @@ static int parse_compass(const char *restrict str, int *n) {
   *n = 0;
 
   // Skip underscores and white spaces
-  while(str[from] && (str[from] == '_' || isspace(str[from]) || ispunct(str[from]))) from++;
+  while(str[from] && (str[from] == '_' || isspace((unsigned char)str[from]) || ispunct((unsigned char)str[from]))) from++;
 
   // Compass direction (if any)
   if(sscanf(&str[from], "%6s", compass) > 0) {
     int i;
 
     for(i = 0; compass[i]; i++)
-      if(compass[i] == '_' || ispunct(compass[i])) {
+      if(compass[i] == '_' || ispunct((unsigned char)compass[i])) {
         compass[i] = '\0';
         break;
       }
@@ -461,7 +461,7 @@ double novas_dms_degrees(const char *restrict dms) {
   errno = 0;
 
   // Skip trailing white spaces / punctuation
-  while(*tail && (isspace(*tail) || ispunct(*tail))) tail++;
+  while(*tail && (isspace((unsigned char)*tail) || ispunct((unsigned char)*tail))) tail++;
   if(*tail)
     errno = EINVAL;
 
@@ -543,7 +543,7 @@ double novas_parse_degrees(const char *restrict str, char **restrict tail) {
   sign = parse_compass(str, &nc);
   next = (char *) str + nc;
 
-  while(*next && isspace(*next)) next++;
+  while(*next && isspace((unsigned char)*next)) next++;
 
   if(sscanf(next, "%79[-+0-9.]", num) > 0) {
     char *end = num;
@@ -557,7 +557,7 @@ double novas_parse_degrees(const char *restrict str, char **restrict tail) {
       int n1, nu = 0;
 
       // Check if exponential notation.
-      if(toupper(next[n]) == 'E' && next[n+1] && !isspace(next[n+1]) && next[n+1] != '_') {
+      if(toupper((unsigned char)next[n]) == 'E' && next[n+1] && !isspace((unsigned char)next[n+1]) && next[n+1] != '_') {
         int exp = strtol(&next[n+1], &end, 10);
         if(end > &next[n+1]) {
           deg *= pow(10.0, exp);
@@ -566,7 +566,7 @@ double novas_parse_degrees(const char *restrict str, char **restrict tail) {
       }
 
       // Skip underscores and white spaces
-      for(n1 = n; next[n1] && (next[n1] == '_' || isspace(next[n1]));) n1++;
+      for(n1 = n; next[n1] && (next[n1] == '_' || isspace((unsigned char)next[n1]));) n1++;
 
       // Skip over unit specification
       if(sscanf(&next[n1], "%8s%n", unit, &nu) > 0) {
@@ -574,7 +574,7 @@ double novas_parse_degrees(const char *restrict str, char **restrict tail) {
         int i;
 
         // Terminate unit at punctuation
-        for(i = 0; unit[i]; i++) if(unit[i] == '_' || ispunct(unit[i])) {
+        for(i = 0; unit[i]; i++) if(unit[i] == '_' || ispunct((unsigned char)unit[i])) {
           unit[i] = '\0';
           nu = i;
           break;
@@ -671,7 +671,7 @@ double novas_parse_hours(const char *restrict str, char **restrict tail) {
     int n1, n2 = 0;
 
     // Skip underscores and white spaces
-    for(n1 = n; str[n1] && (str[n1] == '_' || isspace(str[n1])); n1++);
+    for(n1 = n; str[n1] && (str[n1] == '_' || isspace((unsigned char)str[n1])); n1++);
 
     // Skip over unit specification
     if(sscanf(&str[n1], "%6s%n", unit, &n2) > 0) {
@@ -679,7 +679,7 @@ double novas_parse_hours(const char *restrict str, char **restrict tail) {
       int i;
 
       // Terminate unit at punctuation
-      for(i = 0; unit[i]; i++) if(unit[i] == '_' || ispunct(unit[i])) {
+      for(i = 0; unit[i]; i++) if(unit[i] == '_' || ispunct((unsigned char)unit[i])) {
         unit[i] = '\0';
         n2 = i;
         break;
@@ -736,7 +736,7 @@ double novas_str_degrees(const char *restrict str) {
   errno = 0;
 
   // Skip trailing white spaces / punctuation
-  while(*tail && (isspace(*tail) || ispunct(*tail))) tail++;
+  while(*tail && (isspace((unsigned char)*tail) || ispunct((unsigned char)*tail))) tail++;
   if(*tail)
     errno = EINVAL;
 
@@ -775,7 +775,7 @@ double novas_str_hours(const char *restrict str) {
   errno = 0;
 
   // Skip trailing white spaces / punctuation
-  while(*tail && (isspace(*tail) || ispunct(*tail))) tail++;
+  while(*tail && (isspace((unsigned char)*tail) || ispunct((unsigned char)*tail))) tail++;
   if(*tail)
     errno = EINVAL;
 
@@ -787,7 +787,7 @@ static int skip_white(const char *str, char **tail) {
 
   // Consume trailing 'white' spaces / punctuation
   for(; *next; next++)
-    if(!isspace(*next) && *next != '_')
+    if(!isspace((unsigned char)*next) && *next != '_')
       break;
 
   *tail = next;
@@ -807,7 +807,7 @@ static int parse_zone(const char *str, char **tail) {
     int sign = *(next++) == '-' ? -1 : 1;
     int colon = 0;
 
-    if(isdigit(next[0]) && isdigit(next[1])) {
+    if(isdigit((unsigned char)next[0]) && isdigit((unsigned char)next[1])) {
       H = 10 * (next[0] - '0') + (next[1] - '0');
       if(H >= 24)
         return novas_error(-1, EINVAL, fn, "invalid zone hours: %d, expected [0-23]", H);
@@ -821,8 +821,8 @@ static int parse_zone(const char *str, char **tail) {
       colon = 1;
     }
 
-    if(isdigit(next[0])) {
-      if(!isdigit(next[1]))
+    if(isdigit((unsigned char)next[0])) {
+      if(!isdigit((unsigned char)next[1]))
         return novas_error(-1, EINVAL, fn, "invalid time zone specification");
 
       M = 10 * (next[0] - '0') + (next[1] - '0');

--- a/src/c99/refract.c
+++ b/src/c99/refract.c
@@ -10,7 +10,6 @@
  * @sa novas_app_to_hor(), novas_hor_to_app()
  */
 
-#include <stdlib.h>
 #include <string.h>
 #include <errno.h>
 

--- a/src/c99/timescale.c
+++ b/src/c99/timescale.c
@@ -15,10 +15,13 @@
 #  define _POSIX_C_SOURCE 199309L   ///< struct timespec
 #endif
 #define __NOVAS_INTERNAL_API__      ///< Use definitions meant for internal use by SuperNOVAS only
+// NOVAS_NO_LIBC implies NOVAS_NO_SYSTEM_CLOCK: no clock_gettime() / timespec_get()
+#if defined(NOVAS_NO_LIBC) && !defined(NOVAS_NO_SYSTEM_CLOCK)
+#  define NOVAS_NO_SYSTEM_CLOCK 1
+#endif
 /// \endcond
 
 #include <stdio.h>    // snprintf()
-#include <stdlib.h>
 #include <string.h>
 #include <errno.h>
 #include <math.h>

--- a/src/c99/util.c
+++ b/src/c99/util.c
@@ -8,7 +8,9 @@
  */
 
 #include <stdarg.h>               // before stdio for vfprintf on LynxOS 3.1
-#include <stdio.h>                // snprintf()
+#ifndef NOVAS_NO_LIBC
+#  include <stdio.h>              // vfprintf()
+#endif
 #include <string.h>
 #include <errno.h>
 
@@ -22,32 +24,44 @@
 #define MAX_SECONDS_DECIMALS      9                 ///< Maximum decimal places for seconds in HMS/DMS formats
 /// \endcond
 
-/// Current debugging state for reporting errors and traces to stderr.
-static enum novas_debug_mode novas_debug_state = NOVAS_DEBUG_OFF;
+
+#ifdef NOVAS_NO_LIBC
+#  define DEFAULT_ERROR_HANDLER   NULL                    ///< No default errro handler without LIBC
+#else
+#  define DEFAULT_ERROR_HANDLER   default_error_handler   ///< Prints debug error messages to `stderr`.
 
 /// Default error handler: writes the formatted message to stderr.
 static void default_error_handler(const char *fmt, va_list args) {
   vfprintf(stderr, fmt, args);
 }
+#endif // LIBC
 
-/// Active error messages handler
-static novas_error_handler error_handler_fn = default_error_handler;
+
+/// Current debugging state for reporting errors and traces to stderr.
+static enum novas_debug_mode novas_debug_state = NOVAS_DEBUG_OFF;
+
+/// Active error handler; restored to default_error_handler when NULL is passed to novas_set_error_handler().
+static novas_error_handler error_handler_fn = DEFAULT_ERROR_HANDLER;
 
 /**
  * Replaces the trace / error message handler. Pass NULL to restore the default error reporting to
  * `stderr`. Or, to silence error output entirely, use `novas_debug(NOVAS_DEBUG_OFF)`.
  *
- * @param handler  new handler, or NULL to restore the default error messaging to `stderr`.
+ * When built with `NOVAS_NO_LIBC` there is no default stderr handler, so passing NULL silences
+ * output entirely (same effect as `novas_debug(NOVAS_DEBUG_OFF)`).
+ *
+ * @param handler  new handler, or NULL to restore the default error messaging to `stderr`
+ *                 (or to silence output when built with `NOVAS_NO_LIBC`).
  * @return         the previous handler (so it can be restored or chained)
  *
  * @since 1.7
- * @author Kiran Shila
+ * @author Kiran Shila, Attila Kovacs
  *
  * @sa novas_debug()
  */
 novas_error_handler novas_set_error_handler(novas_error_handler handler) {
   novas_error_handler prev = error_handler_fn;
-  error_handler_fn = handler ? handler : default_error_handler;
+  error_handler_fn = handler ? handler : DEFAULT_ERROR_HANDLER;
   return prev;
 }
 


### PR DESCRIPTION
## Summary

Adds the `NOVAS_NO_LIBC` preprocessor flag and the `ENABLE_LIBC` (c)make option to set it, conditionally turning off all the libc and stdlib stuff not typically available on bare-metal platforms.

## Fixes
- in parse.c, `is*()` functions need unsigned chars and passing char is technically UB for non-ASCII input (caught in -Werror on ARM)