### PR TITLE
Consolidate new v1.7 build options

### DIFF
--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -89,7 +89,7 @@ jobs:
             cmake --build build
             cmake --install build --prefix install
             ls -la install/
-
+      
   build-doc:
     runs-on: ubuntu-latest
     name: Build Documentation (Ubuntu)
@@ -101,7 +101,7 @@ jobs:
 
       - name: Build HTML documentation
         run: |
-          cmake -B build -DENABLE_CPP=ON -DBUILD_DOC=ON
+          cmake -B build -DENABLE_CPP=ON -DBUILD_DOC=ON -DWITHOUT_CURL=ON
           cmake --build build
 
       - name: Install docs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,14 +148,14 @@ jobs:
   build-mcu:
     runs-on: ubuntu-latest
     name: Embedded ARM
+    env:
+      CC: arm-none-eabi-gcc
+      # As an example, compile a static library for the RP2350 microcontroller
+      CFLAGS: -mcpu=cortex-m33 -mthumb -mfloat-abi=hard -mfpu=fpv5-sp-d16 -Os -Wall -Werror
     steps:
       - uses: actions/checkout@v6
 
       - uses: carlosperate/arm-none-eabi-gcc-action@v1
 
-      - name: Build static library (bare-metal, no-libc)
-        # As an example, compile a static library for the RP2350 microcontroller
-        run: >
-          make CC=arm-none-eabi-gcc WITHOUT_LIBC=1
-          CFLAGS="-mcpu=cortex-m33 -mthumb -mfloat-abi=hard -mfpu=fpv5-sp-d16 -Os -Wall -Werror"
-          static
+      - name: Build static library
+        run: make WITHOUT_LIBC=1 static

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Release candidate for the upcoming feature release, possibly around 1 August 202
 
  - #313: Support for fetching of leap-seconds and EOP data from IERS, also automatically as needed when the EOP 
    parameters supplied for initializing astrometric time or an observing frame are left undefined (NAN). These 
-   features require cURL (`curl` library) support, and may not be available if __SuperNOVAS__ was built without it. 
+   features require cURL (`libcurl` library) support, and may not be available if __SuperNOVAS__ was built without it. 
    Various new functions (in `iers.c`) also control what URLs (or local files) are used for leap seconds and EOP 
    data.
 
@@ -50,13 +50,14 @@ Release candidate for the upcoming feature release, possibly around 1 August 202
  - #326: New `novas_set_error_handler()` (and `novas_error_handler` typedef) to route `novas_trace()` / 
    `novas_error()` output through a user-supplied callback instead of `fprintf(stderr, ...)`. (by kiranshila)
 
- - #326: New `NOVAS_NO_SYSTEM_CLOCK` compiler flag to build without `clock_gettime()` / `timespec_get()` calls for 
+ - #326: New `WITHOUT_SYSTEM_CLOCK` precompiler flag to build without `clock_gettime()` / `timespec_get()` calls for 
    targets without real-time clock (e.g. embedded, freestanding). If set during the build, `novas_set_current_time()` 
-   will simply return an error. (by @kiranshila)
+   will simply return an error. (by kiranshila)
 
- - `WITHOUT_LIBC=1` build mode for freestanding targets (bare-metal, WebAssembly) with no libc file I/O, heap, or
-   system clock. Automatically sets `NOVAS_NO_LIBC=1` and `NOVAS_NO_SYSTEM_CLOCK=1`, and forces `CURL_SUPPORT=0`.
-   CI now cross-compiles and verifies the static library for ARM Cortex-M33.
+ - #331: `WITHOUT_LIBC` build mode for freestanding targets (bare-metal, WebAssembly) with no libc file I/O, heap, or
+   system clock. Automatically sets the `WITHOUT_LIBC`, `WITHOUT_CLOCK`, and `WITHOUT_CURL` preprocessor options. The 
+   CI now cross-compiles and verifies the static library for ARM Cortex-M33. (by kiranshila)
+   
 ### Changed
 
  - #313: `novas_set_time()` and related similar functions, can now fetch leap seconds and the mean interpolated 
@@ -83,6 +84,9 @@ Release candidate for the upcoming feature release, possibly around 1 August 202
    all of which came at the same time or after the `orbit` field was added. Hence they are always safe to use. And, 
    document other `object` initializers to note that they do not initialize the `orbit` fields with zeroes for 
    back-compatibility reasons. (thanks to kiranshila)
+   
+ - #333: More consistent build configuration, improved use of feature tests macros where necessary, and mention
+   build options in API docs where approriate.
    
  - Precision in `novas_set_split_time()` to be independent of the choice of integer/double split of the parameters, 
    beyond the precision of the split itself.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,19 +40,19 @@ option(BUILD_DOC "Build HTML documentation" OFF)
 option(BUILD_TESTING "Build regression test suite" ON)
 option(BUILD_EXAMPLES "Build example programs" OFF)
 option(BUILD_BENCHMARK "Build benchmark programs" OFF)
-option(WITHOUT_CURL "Build without cURL support (no fetching EOP from IERS possible)" ON)
+option(WITHOUT_CURL "Build without cURL support (no fetching EOP from IERS possible)" OFF)
+option(WITHOUT_LIBC "Build without libc-dependent features (file I/O, heap, system clock). Enable for bare-metal/WASM targets." OFF)
 option(ENABLE_CPP "Enable C++ library build (supernovas++ library)" OFF)
 option(ENABLE_CALCEPH "Enable CALCEPH support (solsys-calceph plugin)" OFF)
 option(ENABLE_CSPICE "Enable CSPICE support (solsys-cspice plugin)" OFF)
 option(ENABLE_TESTING_ONLINE "Run online tests requiring internet access" OFF)
-option(WITHOUT_LIBC "Build without libc-dependent features (file I/O, heap, system clock). Enable for bare-metal/WASM targets." OFF)
 
 if(WITHOUT_LIBC)
+    message(STATUS "WITHOUT_LIBC=ON: forcing WITHOUT_CURL=ON, ENABLE_CPP/CALCEPH/CSPICE=OFF")
     set(WITHOUT_CURL ON CACHE BOOL "Forced ON: WITHOUT_LIBC=ON" FORCE)
     set(ENABLE_CPP OFF CACHE BOOL "Forced OFF: WITHOUT_LIBC=ON" FORCE)
     set(ENABLE_CALCEPH OFF CACHE BOOL "Forced OFF: WITHOUT_LIBC=ON" FORCE)
     set(ENABLE_CSPICE OFF CACHE BOOL "Forced OFF: WITHOUT_LIBC=ON" FORCE)
-    message(STATUS "WITHOUT_LIBC=ON: forcing WITHOUT_CURL=ON, ENABLE_CPP/CALCEPH/CSPICE=OFF")
 endif()
 
 # Set feature descriptions for summary
@@ -111,8 +111,8 @@ if(HAS_MATHLIB)
 endif()
 
 if(NOT WITHOUT_CURL)
-   find_library(curl_FOUND curl REGISTRY_VIEW TARGET REQUIRED)   
-   set(LIBCURL curl)
+   find_package(CURL)
+   set(LIBCURL CURL::libcurl)
    
    # [.pc] Link applications against curl lib...
    string(APPEND PC_LIBS_PRIVATE -l${LIBCURL} " ")

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,6 @@ dox local-dox:
 	$(MAKE) -C doc
 
 
-
 # ----------------------------------------------------------------------------
 # Install targets and recipes
 # ----------------------------------------------------------------------------
@@ -231,11 +230,11 @@ summary:
 	@echo
 	@echo "SuperNOVAS build configuration:"
 	@echo
+	@echo "    ENABLE_CPP           = $(ENABLE_CPP)"
+	@echo "    WITHOUT_LIBC         = $(WITHOUT_LIBC)"
+	@echo "    WITHOUT_CURL         = $(WITHOUT_CURL)"
 	@echo "    CALCEPH_SUPPORT      = $(CALCEPH_SUPPORT)"
 	@echo "    CSPICE_SUPPORT       = $(CSPICE_SUPPORT)"
-	@echo "    ENABLE_CPP           = $(ENABLE_CPP)"
-	@echo "    SOLSYS_SOURCES       = $(SOLSYS_SOURCES)"
-	@echo "    READEPH_SOURCES      = $(READEPH_SOURCES)"
 	@echo
 	@echo "    CC      = $(CC)" 
 	@echo "    CFLAGS  = $(CFLAGS)"

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Optional dependencies:
  
 #### Installing dependencies on Linux
 
+<details>
 On Fedora / EPEL Linux and derivatives, you may install all packaged (build + runtime) dependencies as:
 
 ```bash
@@ -248,23 +249,28 @@ And on Debian and derivatives (e.g. Ubuntu, Mint, Alpine), you may do the same w
 ```bash
   sudo apt-get install libcurl4-openssl-dev calceph-dev doxygen
 ```
+</details>
 
 #### Installing dependencies on MacOS
 
+<details>
 On MacOS you may install the dependencies with Homebrew:
 
 ```bash
   brew install curl calceph doxygen
 ```
+</details>
 
 #### Installing dependencies on BSD
 
+<details>
 On BSD (e.g. FreeBSD, OpenBSD) you might install `curl` and `calceph`. And you will also need additional packages for 
 building __SuperNOVAS__, such as and `cmake` and/or `gmake`, and `pkgconf`:
 
 ```bash
   pkg install -y gmake cmake devel/pkgconf curl calceph 
 ```
+</details>
 
 <a name="gnu-build"></a>
 ### Build SuperNOVAS using GNU make
@@ -322,12 +328,13 @@ Additionally, you may set number of environment variables to futher customize th
 
  - `CHECKEXTRA`: Extra options to pass to `cppcheck` for the `make check` target
  
- - `CURL_SUPPORT`: Setting to 0 disables building against `libcurl` (default: 1). If disabled, the EOP fetching 
-   functions and methods will return an error or invalid EOP, with `errno` set to `ENOSYS`.
+ - `WITHOUT_CURL`: Setting to 1 disables building against `libcurl`. Without cURL support, the EOP fetching functions 
+   and methods will return an error or invalid EOP, with `errno` set to `ENOSYS`.
 
- - `WITHOUT_LIBC`: Setting to 1 builds the library for bare-metal or WebAssembly targets
-   that have no libc file I/O, heap allocator, or system clock. This sets the `NOVAS_NO_LIBC` and 
-   `NOVAS_NO_SYSTEM_CLOCK` preprocessor flags, and forces `CURL_SUPPORT=0`. See the 
+ - `WITHOUT_LIBC`: Setting to 1 builds the library for bare-metal or WebAssembly targets that have no libc file I/O, 
+   heap allocator, or system clock. This sets the `WITHOUT_LIBC`, `WITHOUT_SYSTEM_CLOCK`, and `WITHOUT_CURL` 
+   preprocessor flags. Without `libc` support, you cannot use the system clock to set current time, and/or manage
+   leap seconds and Earth Orientation Parameters automatically. You must set these explicitly instead. See 
    [Cross-compiling for embedded targets](#cross-compile) section below.
  
  - `DOXYGEN`: Specify the `doxygen` executable to use for generating documentation. If not set (default), `make` will
@@ -402,13 +409,11 @@ Now you can build __SuperNOVAS__, for example as a shared library, with:
 <a name="cross-compile"></a>
 #### Cross-compiling for embedded targets
 
-<details>
-
 __SuperNOVAS__ can be compiled as a static library for bare-metal embedded systems (e.g. ARM Cortex-M) or WebAssembly
-targets. Set `WITHOUT_LIBC=1` to build in freestanding mode, which disables all libc file I/O, heap allocation, and
-system clock dependencies:
+targets (as of v1.7). Set `WITHOUT_LIBC=1` to build in freestanding mode, which disables all libc file I/O, heap 
+allocation, and system clock dependencies:
 
-
+<details>
 For embedded ARM, this may look like:
 
 ```bash
@@ -455,6 +460,8 @@ The __SuperNOVAS__ CMake build supports the following options (in addition to th
  - `BUILD_BENCHMARK=ON|OFF` (default: OFF) - Build benchmarking programs 
  - `WITHOUT_CURL=ON|OFF` (default: OFF) - Build without [cURL](https://curl.se/) support (fetching EOP from IERS will 
    not be possible without cURL support).
+ - `WITHOUT_LIBC=ON|OFF` (default: OFF) - Build for bare-metal or WebAssembly targets that have no libc file I/O, heap 
+   allocator, or system clock.
  - `ENABLE_CPP=ON|OFF` (default: OFF) - Build C++11 library (`supernovas++`) also. 
  - `ENABLE_CALCEPH=ON|OFF` (default: OFF) - Optional CALCEPH ephemeris plugin support. Requires `calceph` package.
  - `ENABLE_CSPICE=ON|OFF` (default: OFF) - Optional CSPICE ephemeris plugin support. Requires `cspice` library 

--- a/config.mk
+++ b/config.mk
@@ -63,15 +63,19 @@ CFLAGS ?= -g -Os -Wall
 #CSPICE_SUPPORT = 1
 
 
-# Build with cURL support for obtaining EOP data from IERS. If you don't
-# have access to curl, and do not need the functionality, you may disable
-# it by setting it to 0.
-CURL_SUPPORT = 1
+# Build without cURL support for obtaining EOP data from IERS. If you don't 
+# have access to libcurl, and do not need the functionality, you may disable 
+# it by setting it to 1.
+#WITHOUT_CURL = 1
 
 
 # Set to 1 to build for freestanding targets (bare-metal, WASM) that have no
-# libc file I/O, heap, or system clock. Forces CURL_SUPPORT=0.
-# The C preprocessor flag NOVAS_NO_LIBC=1 is defined automatically.
+# libc file I/O, heap, or system clock. Forces WITHOUT_CURL=1 config also.
+#
+# Setting this option will disable some functionality, like using the system 
+# clock to set current time, or automatically managing leap seconds and Earth 
+# Orientation Parameters (EOP). You must set time, leap seconds, and EOP 
+# explicitly instead, when needed.
 #WITHOUT_LIBC = 1
 
 
@@ -104,6 +108,18 @@ export SUPERNOVAS_BUILD
 
 # The version of the shared .so libraries
 SO_VERSION := 1
+
+# If building without LIBC, force disable the incompatible options.
+ifeq ($(WITHOUT_LIBC), 1)
+  $(info Configured WITHOUT_LIBC: Force disable incompatible config options.)
+
+  override WITHOUT_CURL := 1
+  override CALCEPH_SUPPORT := 0
+  override CSPICE_SUPPORT := 0
+  override ENABLE_CPP := 0
+  
+  CPPFLAGS += -DWITHOUT_LIBC -DWITHOUT_SYSTEM_CLOCK
+endif
 
 # If the THREAD_LOCAL variable was defined externally, use that definition to 
 # specify the thread local keyword to use. 
@@ -168,9 +184,9 @@ endif
 ifeq ($(AUTO_DETECT_LIBS),1)
   # Use ldconfig (if available) to detect dependency shared libs 
   # automatically
-  ifndef CURL_SUPPORT
-    ifneq ($(shell ldconfig -p | grep libcurl), )
-      CURL_SUPPORT = 1
+  ifndef WITHOUT_CURL
+    ifeq ($(shell ldconfig -p | grep libcurl), )
+      WITHOUT_CURL = 1
     endif
   endif
   ifndef CALCEPH_SUPPORT

--- a/include/novas.h
+++ b/include/novas.h
@@ -3721,12 +3721,12 @@ int novas_Rz(double angle, double *v);
 
 int novas_print_decimal(double value, int decimals, char *str, int len);
 
-#if defined(__cplusplus) || __STDC_VERSION__ >= 200809L
-#  ifndef _POSIX_C_SOURCE
-#    define _POSIX_C_SOURCE 200809L ///< for snprintf
-#  endif
+// Check to see if snprintf() is available, or if we should use our own dummy version of it.
+#if !defined(NOVAS_SNPRINTF) && ( defined(snprintf) || defined(__cplusplus) || __STDC_VERSION__ >= 199901L \
+        || defined(_MSC_VER) || defined(_ISOC99_SOURCE) || _XOPEN_SOURCE >= 500 || defined(_BSD_SOURCE) )
 #  define novas_snprintf snprintf
 #else
+#  define NOVAS_SNPRINTF          ///< Use our own dummy version of snprintf(), same as sprintf()
 int novas_snprintf(char *buf, size_t len, const char *fmt, ...);
 #endif
 

--- a/src/c99/CMakeLists.txt
+++ b/src/c99/CMakeLists.txt
@@ -23,11 +23,11 @@ target_include_directories(core PUBLIC
 )
 
 if(WITHOUT_CURL)
-  target_compile_definitions(core PRIVATE WITHOUT_CURL=1)
+  target_compile_definitions(core PRIVATE WITHOUT_CURL)
 endif()
 
 if(WITHOUT_LIBC)
-  target_compile_definitions(core PRIVATE NOVAS_NO_LIBC=1 NOVAS_NO_SYSTEM_CLOCK=1)
+  target_compile_definitions(core PRIVATE WITHOUT_LIBC WITHOUT_SYSTEM_CLOCK)
 endif()
 
 # Allow deprecated functions internally

--- a/src/c99/Makefile
+++ b/src/c99/Makefile
@@ -38,16 +38,8 @@ ifeq ($(CSPICE_SUPPORT), 1)
   SHARED_TARGETS += $(LIB)/libsolsys-cspice.$(SOEXT)
 endif
 
-ifeq ($(WITHOUT_LIBC), 1)
-  CPPFLAGS += -DNOVAS_NO_LIBC=1 -DNOVAS_NO_SYSTEM_CLOCK=1
-  override CURL_SUPPORT := 0
-  override CALCEPH_SUPPORT :=
-  override CSPICE_SUPPORT :=
-  override ENABLE_CPP :=
-endif
-
-ifeq ($(CURL_SUPPORT), 0)
-  CPPFLAGS += -DWITHOUT_CURL=1
+ifeq ($(WITHOUT_CURL), 1)
+  CPPFLAGS += -DWITHOUT_CURL
 else
   LDFLAGS += -lcurl
 endif

--- a/src/c99/frames.c
+++ b/src/c99/frames.c
@@ -488,9 +488,14 @@ int novas_frame_is_initialized(const novas_frame *frame) {
  *
  *  1. This function expects the Earth polar wobble parameters to be defined on a per-frame basis
  *     and will not use the legacy global (undated) orientation parameters set via cel_pole().
+ *
  *  2. The Earth orientation parameters xp, yp should be provided in the same ITRF realization as
  *     the observer location for an Earth-based observer. You can use `novas_itrf_transform_eop()` to
  *     convert the EOP values as necessary.
+ *
+ *  3. If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *    configuration options), then automatic fetching of the polar offsets is not possible. You must
+ *    set `xp` and `yp` appropriately explicitly.
  *
  * @param accuracy    Accuracy requirement, NOVAS_FULL_ACCURACY (0) for the utmost precision or
  *                    NOVAS_REDUCED_ACCURACY (1) if ~1 mas accuracy is sufficient.

--- a/src/c99/iers.c
+++ b/src/c99/iers.c
@@ -2,7 +2,7 @@
  * @file
  *
  * @date Created  on Apr 18, 2026
- * @author Attila Kovacs
+ * @author Attila Kovacs and Kiran Shila
  *
  *  Functions to obtain and manage Earth Orientation data from the International Earth Rotation
  *  and Reference Systems Service (IERS) via HTTPS, or using other (remote or local) URLs.
@@ -16,20 +16,25 @@
  *  @sa \ref earth
  */
 
-#if !defined(_MSC_VER) && !defined(NOVAS_NO_LIBC)
-#  define _GNU_SOURCE               ///< fmemopen (before glibc 2.10)
+#if !defined(_MSC_VER) && !defined(WITHOUT_LIBC)
+#  define _GNU_SOURCE         ///< fmemopen() (before glibc 2.10)
 #endif
 
 #include <errno.h>
 #include <string.h>
 #include <time.h>
 
-#ifndef NOVAS_NO_LIBC
-#  include <stdio.h>
-#  include <stdlib.h>   // atexit(), calloc(), free()
-#  if !WITHOUT_CURL
-#    include <curl/curl.h>
+#ifdef WITHOUT_LIBC
+#  ifndef WITHOUT_CURL
+#    define WITHOUT_CURL      ///< Without libc, we also cannot have cURL...
 #  endif
+#else
+#  include <stdio.h>
+#  include <stdlib.h>         // atexit(), calloc(), free()
+#endif
+
+#ifndef WITHOUT_CURL
+#  include <curl/curl.h>
 #endif
 
 /// \cond PRIVATE
@@ -38,29 +43,22 @@
 
 #include "novas.h"
 
-#ifndef NOVAS_NO_LIBC
-#include "novas-mutex.h"
+#ifndef WITHOUT_LIBC
+#  include "novas-mutex.h"
+#endif
+
+#if SKIP_IERS_DNS_LOOKUP
+#  define IERS_DATACENTER         "141.74.67.212"       ///< datacenter.iers.org
+#  define IERS_LEAP_SERVER        "145.238.80.89"       ///< hpiers.obspm.fr
+#else
+#  define IERS_DATACENTER         "datacenter.iers.org" ///< IERS EOP server name
+#  define IERS_LEAP_SERVER        "hpiers.obspm.fr"     ///< IERS leap-seconds.list server name
 #endif
 
 /// \cond PRIVATE
-
-#  if SKIP_IERS_DNS_LOOKUP
-#    define IERS_DATACENTER         "141.74.67.212"       ///< datacenter.iers.org
-#    define HPIERS                  "145.238.80.89"       ///< hpiers.obspm.fr
-#  else
-#    define IERS_DATACENTER         "datacenter.iers.org" ///< IERS EOP server name
-#    define HPIERS                  "hpiers.obspm.fr"     ///< IERS leap seconds server name
-#  endif
-
-#define LEAP_FILENAME               "leap-seconds.list"
-#define DEFAULT_LEAP_URL            "https://" HPIERS "/iers/bul/bulc/ntp/" LEAP_FILENAME
-#define IERS_LATEST_URL_PREFIX      "https://" IERS_DATACENTER "/data/latestVersion/"
-#define NTP_UNIX_EPOCH              2208988800LL  ///< [s] NTP timestamp of UNIX epoch (1970 Jan 1)
-
-#define RAPID_JD_START              ( NOVAS_JD_MJD0 + 41684.0 )   ///< [day] Julian date of first entry in rapid service file
-#define C04_JD_START                ( NOVAS_JD_MJD0 + 37665.0 )   ///< [day] Julian date of first entry in C04 series file
-#define C01_JD_START                ( NOVAS_JD_MJD0 - 4703.268 )  ///< [day] Julian date of first entry in C01 series file
-#define C01_SPARSE_LINES            440           ///< Number of lines in C01 series with sparser sampling
+#  define LEAP_FILENAME               "leap-seconds.list"
+#  define DEFAULT_LEAP_URL            "https://" IERS_LEAP_SERVER "/iers/bul/bulc/ntp/" LEAP_FILENAME
+#  define NTP_UNIX_EPOCH              2208988800LL  ///< [s] NTP timestamp of UNIX epoch (1970 Jan 1)
 
 /**
  * A individual leap seconds entry in a linked list of leap seconds
@@ -72,20 +70,30 @@ typedef struct iers_leap_entry {
   int leap;         ///< [s] Leap seconds (TAI - UTC time difference)
   struct iers_leap_entry *next;   ///< Link to the next leap entry in list.
 } iers_leap_entry;
-
 /// \endcond
 
-#ifndef NOVAS_NO_LIBC
+// ===========================================================================
+#ifndef WITHOUT_LIBC
+
 static iers_leap_entry *leaps;      ///< Leap seconds list
 static time_t leap_expiration;      ///< UNIX time at which leap seconds list expires.
 static lock_type leap_mutex;        ///< mutex for leap seconds data
 static int leap_mutex_initialized;  ///< whether the leap mutex was initialized;
-#endif
+
+#endif // WITH_LIBC
+// ===========================================================================
 
 
 // ---------------------------------------------------------------------------
-#if !WITHOUT_CURL
+#ifndef WITHOUT_CURL
 /// \cond PRIVATE
+
+#  define IERS_LATEST_URL_PREFIX      "https://" IERS_DATACENTER "/data/latestVersion/"
+
+#  define RAPID_JD_START              ( NOVAS_JD_MJD0 + 41684.0 )   ///< [day] Julian date of first entry in rapid service file
+#  define C04_JD_START                ( NOVAS_JD_MJD0 + 37665.0 )   ///< [day] Julian date of first entry in C04 series file
+#  define C01_JD_START                ( NOVAS_JD_MJD0 - 4703.268 )  ///< [day] Julian date of first entry in C01 series file
+#  define C01_SPARSE_LINES            440           ///< Number of lines in C01 series with sparser sampling
 
 /**
  * IERS data file structural description.
@@ -163,10 +171,11 @@ static lock_type eop_mutex;       ///< Mutex for EOP data (excl. leap) access
 static int eop_mutex_initialized;  ///< Whether EOP mutex was initialized
 
 /// \endcond
-#endif /* !WITHOUT_CURL */
+#endif /* WITH_CURL */
 // ---------------------------------------------------------------------------
 
-#ifndef NOVAS_NO_LIBC
+// ===========================================================================
+#ifndef WITHOUT_LIBC
 
 static void lock_leap() {
   if(!leap_mutex_initialized) {
@@ -259,9 +268,11 @@ static iers_leap_entry *parse_leap_file(FILE *fp, long long *expiration) {
   return list;
 }
 
-#endif /* !NOVAS_NO_LIBC */
+#endif /* WITH_LIBC */
+// ===========================================================================
+
 // ---------------------------------------------------------------------------
-#if !WITHOUT_CURL
+#ifndef WITHOUT_CURL
 
 static void lock_eop() {
   if(!eop_mutex_initialized) {
@@ -606,7 +617,7 @@ static void cleanup_eop_urls_async() {
     }
 }
 
-#endif /* !WITHOUT_CURL */
+#endif /* WITH_CURL */
 // ---------------------------------------------------------------------------
 
 /**
@@ -616,6 +627,11 @@ static void cleanup_eop_urls_async() {
  *
  * It is similar to `novas_set_eop_url()` for the `EOP_LEAP_LIST` series, with a `file://` type
  * URL, except that this one does not need cURL support, and can work with relative paths also.
+ *
+ * NOTES:
+ *
+ *  - If __SuperNOVAS__ was built without `libc` support (`WITHOUT_LIBC` build configuration option),
+ *    then this function will always return an error (`errno` set to `ENOSYS`).
  *
  * @param filename      Path to a local `leap-seconds.list` file (as obtained from IERS or a
  *                      mirror). It is typically included in the `tzdata` package on Linux, where
@@ -633,9 +649,9 @@ static void cleanup_eop_urls_async() {
 int novas_set_leap_list(const char *filename) {
   static const char *fn = "novas_set_leap_list";
 
-#ifdef NOVAS_NO_LIBC
+#ifdef WITHOUT_LIBC
   (void) filename;
-  return novas_error(-1, ENOSYS, fn, "built with NOVAS_NO_LIBC: file I/O unavailable");
+  return novas_error(-1, ENOSYS, fn, "SuperNOVAS was built without libc (WITHOUT_LIBC): file I/O unavailable");
 #else
   FILE *fp;
   iers_leap_entry *list;
@@ -664,7 +680,7 @@ int novas_set_leap_list(const char *filename) {
   novas_unlock(&leap_mutex);
 
   return 0;
-#endif /* !NOVAS_NO_LIBC */
+#endif /* !WITHOUT_LIBC */
 }
 
 /**
@@ -676,6 +692,11 @@ int novas_set_leap_list(const char *filename) {
  * Leap seconds were first introduced on 1 Jan 1972. Thus for date preceding the introduction,
  * 0 is returned. Leap seconds prognosis into the future is available only up to the expiration
  * date of the `leap-seconds.list` file (as supplied or updated from IERS).
+ *
+ * NOTES:
+ *
+ *  - If __SuperNOVAS__ was built without `libc` support (`WITHOUT_LIBC` build configuration option),
+ *    then this function will always return an error (`errno` set to `ENOSYS`).
  *
  * @param t     [s] UNIX time (seconds since 0 UTC, 1 Jan 1970)
  * @return      The leap seconds for the given time, or NOVAS_INVALID_LEAP (-999) if there was an
@@ -690,19 +711,19 @@ int novas_set_leap_list(const char *filename) {
 int novas_lookup_leap(time_t t) {
   static const char *fn = "novas_lookup_leap";
 
-#ifdef NOVAS_NO_LIBC
+#ifdef WITHOUT_LIBC
   (void) t;
-  return novas_error(NOVAS_INVALID_LEAP, ENOSYS, fn, "built with NOVAS_NO_LIBC: supply leap count explicitly");
+  return novas_error(NOVAS_INVALID_LEAP, ENOSYS, fn, "SuperNOVAS was built without libc (WITHOUT_LIBC): specify leap seconds explicitly instead.");
 #else
   const iers_leap_entry *e;
-  char str[40] = {'\0'};
 
   lock_leap();
   if(!leaps || (t >= leap_expiration && time(NULL) >= leap_expiration)) {
-#if WITHOUT_CURL
+
+#  ifdef WITHOUT_CURL
     unlock_leap();
-    return novas_error(NOVAS_INVALID_LEAP, ERANGE, fn, "no leap data available for time %lld", (long long) t);
-#else
+    return novas_error(NOVAS_INVALID_LEAP, ERANGE, fn, "no leap data available for time %lld (WITHOUT_CURL)", (long long) t);
+#  else
     if(novas_is_auto_fetch_eop()) {
       long long expiration = 0LL;
       iers_leap_entry *update = fetch_leaps_async(&expiration);
@@ -716,10 +737,11 @@ int novas_lookup_leap(time_t t) {
       unlock_leap();
       return novas_error(NOVAS_INVALID_LEAP, EAGAIN, fn, "automatic EOP fetching is disabled.");
     }
-#endif
+#  endif
   }
 
   if(t > leaps->unix_end) {
+    char str[40] = {'\0'};
     unlock_leap();
     strftime(str, sizeof(str), "%c", gmtime(&t));
     return novas_error(NOVAS_INVALID_LEAP, ERANGE, fn, "Time %s is beyond the leap seconds coverage range", str);
@@ -734,7 +756,7 @@ int novas_lookup_leap(time_t t) {
   unlock_leap();
 
   return 0;
-#endif /* !NOVAS_NO_LIBC */
+#endif /* !WITHOUT_LIBC */
 }
 
 
@@ -753,7 +775,7 @@ int novas_lookup_leap(time_t t) {
  *
  *  - Requires __SuperNOVAS__ to be compiled with cURL support enabled, otherwise -1 is returned
  *    with `errno` set to `ENOSYS`.
- *
+
  * @param series      The EOP series identifier constant.
  * @param itrf_year   [yr] ITRF realization year. Needed only for precision at the few &mu;as
  *                    level, otherwise, you can set it to something recent, like 2020. It is
@@ -773,8 +795,8 @@ int novas_lookup_leap(time_t t) {
 int novas_set_eop_url(enum novas_eop_series series, int itrf_year, const char *url) {
   static const char *fn = "novas_set_eop_url";
 
-#if WITHOUT_CURL
-  return novas_error(-1, ENOSYS, fn, "SuperNOVAS was built without cURL support");
+#ifdef WITHOUT_CURL
+  return novas_error(-1, ENOSYS, fn, "SuperNOVAS was built without cURL support (WITHOUT_CURL)");
 #else
   static int initialized;
   char *discard;
@@ -846,6 +868,11 @@ int novas_set_eop_url(enum novas_eop_series series, int itrf_year, const char *u
 /**
  * Returns the URL currently configured for a given IERS Earth Orientation Parameter (EOP) series.
  *
+ * NOTES:
+ *
+ *  - If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *    configuration options), then this function will return an error (`errno` set to `ENOSYS`).
+ *
  * @param series    The EOP series identifier constant.
  * @return          The currently configured URL for the given series, or else NULL if the series
  *                  is invalid (`errno` set to `ERANGE`), or if __SuperNOVAS__ was built without
@@ -857,8 +884,8 @@ int novas_set_eop_url(enum novas_eop_series series, int itrf_year, const char *u
  * @sa novas_set_eop_url(), novas_fetch_eop(), novas_get_eop_itrf_year()
  */
 const char *novas_get_eop_url(enum novas_eop_series series) {
-#if WITHOUT_CURL
-  novas_set_errno(ENOSYS, "novas_get_eop_url", "SuperNOVAS was built without cURL support");
+#ifdef WITHOUT_CURL
+  novas_set_errno(ENOSYS, "novas_get_eop_url", "SuperNOVAS was built without cURL support (WITHOUT_CURL)");
   return NULL;
 #else
   const char *url;
@@ -876,6 +903,11 @@ const char *novas_get_eop_url(enum novas_eop_series series) {
 /**
  * Returns the ITRF realization year for a given IERS Earth Orientation Parameter (EOP) series.
  *
+ * NOTES:
+ *
+ *  - If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *    configuration options), then this function will return an error (`errno` set to `ENOSYS`).
+ *
  * @param series    The EOP series identifier constant.
  * @return          [yr] ITRF realization year, e.g. as set by `novas_set_eop_url()`.
  *
@@ -885,8 +917,8 @@ const char *novas_get_eop_url(enum novas_eop_series series) {
  * @sa novas_set_eop_url(), novas_fetch_eop()
  */
 int novas_get_eop_itrf_year(enum novas_eop_series series) {
-#if WITHOUT_CURL
-  return novas_error(-1, EINVAL, "novas_get_eop_itrf_year", "SuperNOVAS was built without cURL support");
+#ifdef WITHOUT_CURL
+  return novas_error(-1, ENOSYS, "novas_get_eop_itrf_year", "SuperNOVAS was built without cURL support (WITHOUT_CURL)");
 #else
   if((unsigned int) series >= NOVAS_NUM_EOP_SERIES)
     return novas_error(-1, EINVAL, "novas_get_eop_itrf_year", "invalid series: %d", (int) series);
@@ -914,18 +946,18 @@ int novas_get_eop_itrf_year(enum novas_eop_series series) {
  * @sa novas_set_leap_list(), novas_fetch_eop()
  */
 void novas_reset_eop() {
-#ifndef NOVAS_NO_LIBC
+#ifndef WITHOUT_LIBC
  lock_leap();
  set_leap_list_async(NULL, 0LL);
  unlock_leap();
+#endif
 
-#  if !WITHOUT_CURL
+#ifndef WITHOUT_CURL
  lock_eop();
  cleanup_eop_urls_async();
  cleanup_eop_handles_async();
  unlock_eop();
-#  endif
-#endif /* !NOVAS_NO_LIBC */
+#endif
 }
 
 /**
@@ -968,6 +1000,9 @@ void novas_reset_eop() {
  *     NAN. (However, the polar the offsets _x_<sub>p</sub> and _y_<sub>p</sub> can be provided
  *     all the way back to 1846, with some precision.)
  *
+ *  8. If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *     configuration options), then this function will return an error (`errno` set to `ENOSYS`).
+ *
  * @param jd              Julian Date (in any timescale, with a preference for UTC)
  * @param timeout_millis  [ms] HTTP connection timeout, or &lt;=0 to leave unchanged.
  * @param[out] eop        Output EOP data structure to populate
@@ -983,8 +1018,8 @@ void novas_reset_eop() {
 int novas_fetch_eop(double jd, long timeout_millis, novas_eop *eop) {
   static const char *fn = "novas_fetch_eop";
 
-#if WITHOUT_CURL
-  return novas_error(-1, ENOSYS, fn, "SuperNOVAS was built without cURL support.");
+#ifdef WITHOUT_CURL
+  return novas_error(-1, ENOSYS, fn, "SuperNOVAS was built without cURL support (WITHOUT_CURL).");
 #else
   static THREAD_LOCAL novas_eop array[4];
   static THREAD_LOCAL double jd_from, jd_to = -1.0;
@@ -1040,6 +1075,9 @@ int novas_fetch_eop(double jd, long timeout_millis, novas_eop *eop) {
  *     data in some other future ITRF realization, this module may need to be updated, accordingly.
  *     However, the ITRF realization is unlikely to matter significantly.
  *
+ *  8. If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *     configuration options), then this function will return an error (`errno` set to `ENOSYS`).
+ *
  * @param t               [s] UNIX time (seconds since 0 UTC 1 Jan 1970).
  * @param timeout_millis  [ms] HTTP connection timeout, or &lt;=0 to leave unchanged.
  * @param[out] eop        Output EOP data structure to populate
@@ -1077,6 +1115,12 @@ int novas_fetch_eop_unix(time_t t, long timeout_millis, novas_eop *eop) {
  * with getting data from IERS, or because you are using __SuperNOVAS__ offline, then simply
  * call this function with FALSE (0) to disable the automatic fetching of EOP values.
  *
+ * NOTES:
+ *
+ *  - If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *    configuration options), then this function will return an error (`errno` set to `ENOSYS`) if
+ *    trying to enable EOP fetching.
+ *
  * @param enabled     TRUE (non-zero) to enabled automatic fetching of EOP values from IERS,
  *                    or else FALSE (0) to disable. By default EOP fetching is enabled.
  *
@@ -1088,9 +1132,9 @@ int novas_fetch_eop_unix(time_t t, long timeout_millis, novas_eop *eop) {
  * @sa Time, Frame, GeodeticObserver, CalendarDate::to_time()
  */
 int novas_set_auto_fetch_eop(int enabled) {
-#if WITHOUT_CURL
+#ifdef WITHOUT_CURL
   if(enabled)
-    return novas_error(-1, ENOSYS, "novas_set_auto_fetch_eop", "SuperNOVAS was built without cURL support.");
+    return novas_error(-1, ENOSYS, "novas_set_auto_fetch_eop", "SuperNOVAS was built without cURL support (WITHOUT_CURL).");
 #else
   auto_fetch_eop = (enabled != 0);
 #endif
@@ -1101,6 +1145,11 @@ int novas_set_auto_fetch_eop(int enabled) {
  * Checks if automatic fetching of Earth Orientation Parameter values from IERS is
  * allowed.
  *
+ * NOTES:
+ *
+ *  - If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *    configuration options), then this function will return an error (`errno` set to `ENOSYS`).
+ *
  * @return    TRUE (1) if automatic fetching of EOP values from IERS is allowed, or else
  *            FALSE (0) if fetching is disabled.
  *
@@ -1110,7 +1159,7 @@ int novas_set_auto_fetch_eop(int enabled) {
  * @sa novas_set_auto_fetch_eop()
  */
 int novas_is_auto_fetch_eop() {
-#if WITHOUT_CURL
+#ifdef WITHOUT_CURL
   return 0;
 #else
   return auto_fetch_eop;

--- a/src/c99/timescale.c
+++ b/src/c99/timescale.c
@@ -10,24 +10,26 @@
  * @sa calendar.c, frames.c, observer.c
  */
 
-/// \cond PRIVATE
-#if !defined(_MSC_VER) && __STDC_VERSION__ < 201112L
-#  define _POSIX_C_SOURCE 199309L   ///< struct timespec
-#endif
-#define __NOVAS_INTERNAL_API__      ///< Use definitions meant for internal use by SuperNOVAS only
-// NOVAS_NO_LIBC implies NOVAS_NO_SYSTEM_CLOCK: no clock_gettime() / timespec_get()
-#if defined(NOVAS_NO_LIBC) && !defined(NOVAS_NO_SYSTEM_CLOCK)
-#  define NOVAS_NO_SYSTEM_CLOCK 1
-#endif
-/// \endcond
+#define _DEFAULT_SOURCE 1           ///< struct timespec
 
-#include <stdio.h>    // snprintf()
+#include <stdio.h>
 #include <string.h>
 #include <errno.h>
 #include <math.h>
 #include <time.h>
 
+/// \cond PRIVATE
+#define __NOVAS_INTERNAL_API__      ///< Use definitions meant for internal use by SuperNOVAS only
+/// \endcond
+
 #include "novas.h"
+
+// WITHOUT_LIBC implies WITHOUT_SYSTEM_CLOCK: no clock_gettime() / timespec_get()
+#ifdef WITHOUT_LIBC
+#  ifndef WITHOUT_SYSTEM_CLOCK
+#    define WITHOUT_SYSTEM_CLOCK    ///< without libc, we also don't have system clock access
+#  endif
+#endif
 
 /// \cond PRIVATE
 #define DTA         32.184                ///< [s] TT - TAI time difference
@@ -437,6 +439,12 @@ double get_ut1_to_tt(int leap_seconds, double dut1) {
  * precision of the double-precision argument. For higher precision applications you may use
  * `novas_set_split_time()` instead, which has an inherent accuracy at the picosecond level.
  *
+ * NOTES:
+ *
+ *  - If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *    configuration options), then automatic fetching of the leap seconds and the UT1 - UTC
+ *    differennce is not possible. You must set `leap` and `dut1` appropriately explicitly.
+ *
  * @param timescale     The astronomical time scale in which the Julian Date is given
  * @param jd            [day] Julian day value in the specified timescale
  * @param leap          [s] Leap seconds, e.g. as published by IERS Bulletin C. (It may be
@@ -471,6 +479,12 @@ int novas_set_time(enum novas_timescale timescale, double jd, int leap, double d
  * Sets astronomical time in a specific timescale using a string specification. It is effectively just
  * a shorthand for using `novas_parse_date()` followed by `novas_set_time()` and the error checking
  * in-between.
+ *
+ * NOTES:
+ *
+ *  - If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *    configuration options), then automatic fetching of the leap seconds and the UT1 - UTC
+ *    differennce is not possible. You must set `leap` and `dut1` appropriately explicitly.
  *
  * @param timescale     The astronomical time scale in which the Julian Date is given
  * @param str           The astronomical date specification, possibly including time and timezone,
@@ -547,6 +561,11 @@ static double tt_offset(const novas_timespec *ts, enum novas_timescale timescale
  * The accuracy of Barycentric Time measures (TDB and TCB) relative to other time measures is
  * limited by the precision of `tdb2tt()` implementation, to around 10 &mu;s.
  *
+ * NOTES:
+ *
+ *  - If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *    configuration options), then automatic fetching of the leap seconds and the UT1 - UTC
+ *    differennce is not possible. You must set `leap` and `dut1` appropriately explicitly.
  *
  * REFERENCES:
  *
@@ -913,6 +932,12 @@ double novas_diff_tcg(const novas_timespec *t1, const novas_timespec *t2) {
  * nanoseconds is a common way CLIB handles precision time, e.g. with `struct timespec` and
  * functions like `clock_gettime()` or the C11 `timespec_get` (see `time.h`).
  *
+ * NOTES:
+ *
+ *  - If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *    configuration options), then automatic fetching of the leap seconds and the UT1 - UTC
+ *    differennce is not possible. You must set `leap` and `dut1` appropriately explicitly.
+ *
  * @param unix_time   [s] UNIX time (UTC) seconds
  * @param nanos       [ns] UTC sub-second component
  * @param leap        [s] Leap seconds, e.g. as published by IERS Bulletin C. (It may be
@@ -964,9 +989,14 @@ int novas_set_unix_time(time_t unix_time, long nanos, int leap, double dut1, nov
  *  1. With MSC, this function uses the C11 standard `timespec_get()` function, which is
  *     portable. For older C standard, the POSIX only `clock_gettime()` function is used.
  *
- *  2. If __SuperNOVAS__ is built with the `NOVAS_NO_SYSTEM_CLOCK` option, then this function
- *     will always return an error. You may want to set the time explicitly with one of the
- *     other functions instead.
+ *  2. If __SuperNOVAS__ was built with the `WITHOUT_SYSTEM_CLOCK` preprocessor flag (or with the
+ *     `WITHOUT_LIBC` build configuration option), then this function will always return an error
+ *     (`errno` set to `ENOSYS`). You may want to set the time explicitly with one of the other
+ *     functions instead.
+ *
+ *  3. If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *     configuration options), then automatic fetching of the leap seconds and the UT1 - UTC
+ *     differennce is not possible. You must set `leap` and `dut1` appropriately explicitly.
  *
  * @param leap        [s] Leap seconds, e.g. as published by IERS Bulletin C. (It may be
  *                    unused if `dut1` is NAN -- see below).
@@ -989,12 +1019,12 @@ int novas_set_unix_time(time_t unix_time, long nanos, int leap, double dut1, nov
  * @sa novas_set_auto_fetch_eop(), novas_lookup_leap(), novas_fetch_eop()
  */
 int novas_set_current_time(int leap, double dut1, novas_timespec *restrict time) {
-#ifdef NOVAS_NO_SYSTEM_CLOCK
+#ifdef WITHOUT_SYSTEM_CLOCK
   (void) leap;
   (void) dut1;
   (void) time;
   return novas_error(-1, ENOSYS, "novas_set_current_time",
-          "system clock support disabled at build time (NOVAS_NO_SYSTEM_CLOCK); "
+          "system clock support disabled at build time (WITHOUT_SYSTEM_CLOCK); "
           "use novas_set_unix_time() with an externally-supplied time instead");
 #else
   struct timespec t = {};

--- a/src/c99/util.c
+++ b/src/c99/util.c
@@ -4,13 +4,11 @@
  *  Various commonly used routines used throughout the SuperNOVAS library.
  *
  * @date Created  on Mar 6, 2025
- * @author G. Kaplan and Attila Kovacs
+ * @author G. Kaplan, Attila Kovacs, and Kiran Shila
  */
 
 #include <stdarg.h>               // before stdio for vfprintf on LynxOS 3.1
-#ifndef NOVAS_NO_LIBC
-#  include <stdio.h>              // vfprintf()
-#endif
+#include <stdio.h>                // vfprintf()
 #include <string.h>
 #include <errno.h>
 
@@ -25,8 +23,8 @@
 /// \endcond
 
 
-#ifdef NOVAS_NO_LIBC
-#  define DEFAULT_ERROR_HANDLER   NULL                    ///< No default errro handler without LIBC
+#ifdef WITHOUT_LIBC
+#  define DEFAULT_ERROR_HANDLER   NULL                    ///< No default error handler without LIBC
 #else
 #  define DEFAULT_ERROR_HANDLER   default_error_handler   ///< Prints debug error messages to `stderr`.
 
@@ -47,11 +45,11 @@ static novas_error_handler error_handler_fn = DEFAULT_ERROR_HANDLER;
  * Replaces the trace / error message handler. Pass NULL to restore the default error reporting to
  * `stderr`. Or, to silence error output entirely, use `novas_debug(NOVAS_DEBUG_OFF)`.
  *
- * When built with `NOVAS_NO_LIBC` there is no default stderr handler, so passing NULL silences
+ * When built with `WITHOUT_LIBC` there is no default stderr handler, so passing NULL silences
  * output entirely (same effect as `novas_debug(NOVAS_DEBUG_OFF)`).
  *
  * @param handler  new handler, or NULL to restore the default error messaging to `stderr`
- *                 (or to silence output when built with `NOVAS_NO_LIBC`).
+ *                 (or to silence output when built with `WITHOUT_LIBC`).
  * @return         the previous handler (so it can be restored or chained)
  *
  * @since 1.7
@@ -89,11 +87,10 @@ int novas_inv_max_iter = 100;
 
 /// \cond PROTECTED
 
-#if !__cplusplus && !(__STDC_VERSION__ >= 200809L)
-
+#ifdef NOVAS_SNPRINTF
 /**
  * A dummy local `snprintf()` implementation when it is not provided by libc, such as on some very
- * old platforms. It simpy behaves like `sprintf()`, ignoring the `len` argument altogether.
+ * old platforms. It simply behaves like `sprintf()`, ignoring the `len` argument altogether.
  *
  * @param buf     buffer to print to
  * @param len     maximum number of characters that can be printed in the buffer (ignored)
@@ -113,7 +110,7 @@ int novas_snprintf(char *buf, size_t len, const char *fmt, ...) {
   va_end(varg);
   return n;
 }
-#endif
+#endif  // NOVAS_SNPRINTF
 
 /**
  * (_for internal use_) Propagates an error (if any) with an offset. If the error is
@@ -627,7 +624,7 @@ int spin(double angle, const double *in, double *out) {
  *
  * @param pos       Position 3-vector, equatorial rectangular coordinates.
  * @param[out] ra   [h] Right ascension in hours [0:24] or NAN if the position vector is NULL or a
- *                  null-vector. It may be NULL if notrequired.
+ *                  null-vector. It may be NULL if not required.
  * @param[out] dec  [deg] Declination in degrees [-90:90] or NAN if the position vector is NULL or
  *                  a null-vector. It may be NULL if not required.
  * @return          0 if successful, -1 of any of the arguments are NULL, or
@@ -1117,16 +1114,16 @@ int novas_offset_by(double lon, double lat, double direction, double distance, d
  * Calculates offset equatorial coordinates at some distance away from the input coordinates along
  * a great circle which crosses the input position at the specified position angle.
  *
- * @param ra              [deg] reference point right ascention (R.A.)
+ * @param ra              [deg] reference point right ascension (R.A.)
  * @param dec             [deg] reference point declination
  * @param direction       [deg] direction (measured East of North).
  * @param distance        [deg] offset distance on great circle
- * @param[out] out_ra     [deg] right ascention (R.A.) at offset position in [0:24) range. It may
+ * @param[out] out_ra     [deg] right ascension (R.A.) at offset position in [0:24) range. It may
  *                        be NULL if not needed.
  * @param[out] out_dec    [deg] declination at offset position in [-&pi/2:&pi;/2] range. It may be
  *                        NULL if not needed.
  * @return                0 if successful, or else -1 if very close to the pole, and right
- *                        ascention (R.A.) at the offset position is requested, or if the
+ *                        ascension (R.A.) at the offset position is requested, or if the
  *                        input declination is outside of the [-90:90] range.
  *
  * @since 1.7

--- a/src/cpp/Calendar.cpp
+++ b/src/cpp/Calendar.cpp
@@ -674,6 +674,12 @@ Time CalendarDate::to_time(int leap_seconds, double dut1, novas_timescale timesc
  * accuracy at the 0.1 ms level only, hence the resulting astronomical time will be limited
  * to the same level of precision also.
  *
+ * NOTES:
+ *
+ * - If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *   configuration options), then automatic fetching of the leap seconds and the UT1 - UTC
+ *   differennce is not possible. You must set a valid EOP explicitly.
+ *
  * @param eop             (optional) Earth Orientation Parameters (EOP) for this date, or
  *                        EOP::undefined() to fetch from IERS for dates after 1 Jan 1956, if
  *                        possible and allowed.

--- a/src/cpp/EOP.cpp
+++ b/src/cpp/EOP.cpp
@@ -204,6 +204,10 @@ std::string EOP::to_string() const {
  * - The returned data does not include diurnal variations for ocean tides and libration.
  *   These are added automatically in the constructors of Time and Frame as neeed.
  *
+ * - If __SuperNOVAS__ was built withut cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *   configuration options), then this function will return an invalid / undefined EOP (`errno`
+ *   set to `ENOSYS`).
+ *
  * @param jd              [day] Julian Date (preferably UTC-based).
  * @param timeout_millis  [ms] (optional) HTTP connection timeout, or &lt;=0 to leave unchanged.
  * @return        EOP obtained from IERS or else an invalid EOP if there was an error (errno will
@@ -244,6 +248,10 @@ EOP EOP::fetch_for_jd(double jd, long timeout_millis) {
  * - The returned data does not include diurnal variations for ocean tides and libration.
  *   These are added automatically in the constructors of Time and Frame as neeed.
  *
+ * - If __SuperNOVAS__ was built withut cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *   configuration options), then this function will return an invalid / undefined EOP (`errno`
+ *   set to `ENOSYS`).
+ *
  * @param mjd             [day] Modified Julian Date (preferably UTC-based).
  * @param timeout_millis  [ms] (optional) HTTP connection timeout, or &lt;=0 to leave unchanged.
  * @return        EOP obtained from IERS or else an invalid EOP if there was an error (errno will
@@ -274,6 +282,10 @@ EOP EOP::fetch_for_mjd(double mjd, long timeout_millis) {
  *
  * - The returned data does not include diurnal variations for ocean tides and libration.
  *   These are added automatically in the constructors of Time and Frame as neeed.
+ *
+ * - If __SuperNOVAS__ was built withut cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *   configuration options), then this function will return an invalid / undefined EOP (`errno`
+ *   set to `ENOSYS`).
  *
  * @param time            UNIX time for which to try get EOP.
  * @param timeout_millis  [ms] (optional) HTTP connection timeout, or &lt;=0 to leave unchanged.
@@ -306,6 +318,10 @@ EOP EOP::fetch_for(const time_t time, long timeout_millis) {
  * - The returned data does not include diurnal variations for ocean tides and libration.
  *   These are added automatically in the constructors of Time and Frame as neeed.
  *
+ * - If __SuperNOVAS__ was built withut cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *   configuration options), then this function will return an invalid / undefined EOP (`errno`
+ *   set to `ENOSYS`).
+ *
  * @param date            Calendar date for which to try get EOP.
  * @param timeout_millis  [ms] (optional) HTTP connection timeout, or &lt;=0 to leave unchanged.
  * @return        EOP obtained from IERS or else an invalid EOP if there was an error (errno will
@@ -334,6 +350,14 @@ EOP EOP::fetch_for(const CalendarDate& date, long timeout_millis) {
  *
  * - The returned data does not include diurnal variations for ocean tides and libration.
  *   These are added automatically in the constructors of Time and Frame as neeed.
+ *
+ * - If __SuperNOVAS__ was built withut cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *    configuration options), then this function will return an error (`errno` set to `ENOSYS`).
+ *
+ * - If __SuperNOVAS__ was built with the `WITHOUT_SYSTEM_CLOCK` preprocessor flag (or with the
+ *    `WITHOUT_LIBC` build configuration option), then this function will always return an invalid
+ *    / undefined EOP (`errno` set to `ENOSYS`). You may want to set the time explicitly with one
+ *    of the constructors instead.
  *
  * @param offset          [s] (optional) time offset from current time (default: 0.0).
  * @param timeout_millis  [ms] (optional) HTTP connection timeout, or &lt;=0 to leave unchanged.
@@ -366,6 +390,15 @@ EOP EOP::fetch_current(double offset, long timeout_millis) {
  *
  * - The returned data does not include diurnal variations for ocean tides and libration.
  *   These are added automatically in the constructors of Time and Frame as neeed.
+ *
+ * - If __SuperNOVAS__ was built withut cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *    configuration options), then this function will return an invalid / undefined EOP (`errno`
+ *    set to `ENOSYS`).
+ *
+ * - If __SuperNOVAS__ was built with the `WITHOUT_SYSTEM_CLOCK` preprocessor flag (or with the
+ *    `WITHOUT_LIBC` build configuration option), then this function will always return an invalid
+ *    / undefined EOP (`errno` set to `ENOSYS`). You may want to set the time explicitly with one
+ *    of the constructors instead.
  *
  * @param offset          (optional) time offset from current time (default: 0.0).
  * @param timeout_millis  [ms] (optional) HTTP connection timeout, or &lt;=0 to leave unchanged.

--- a/src/cpp/Frame.cpp
+++ b/src/cpp/Frame.cpp
@@ -43,6 +43,12 @@ namespace supernovas {
  * In either case, you can obtain more information on why things went wrong, when they do, by
  * enabling debug mode is enabled via `novas_debug()` prior to constructing a Frame.
  *
+ * NOTES:
+ *
+ *  - If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *    configuration options), then automatic fetching of EOP is not possible. You must define
+ *    a valid EOP explicitly.
+ *
  * @param obs         observer location
  * @param time        time of observation
  * @param accuracy    (optional) NOVAS_FULL_ACCURACY (default) or NOVAS_REDUCED_ACCURACY.
@@ -440,6 +446,12 @@ Apparent Frame::apparent_moon_elp2000(double limit_term) const {
  *
  * Note, that the returned frame may be invalid, if the this observer or the time argument
  * themselves are invalid.
+ *
+ * NOTES:
+ *
+ *  - If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *    configuration options), then automatic fetching of EOP is not possible. You must define
+ *    a valid EOP explicitly.
  *
  * @param obs       %Observer location
  * @param time      Astrometric time of observation

--- a/src/cpp/Time.cpp
+++ b/src/cpp/Time.cpp
@@ -65,6 +65,12 @@ Time::Time(double jd, int leap_seconds, double dUT1, enum novas_timescale timesc
 /**
  * Instantiates an astrometric time instance with the specified time parameters.
  *
+ * NOTES:
+ *
+ * - If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *   configuration options), then automatic fetching of the leap seconds and the UT1 - UTC
+ *   differennce is not possible. You must set a valid EOP explicitly.
+ *
  * @param jd            [day] Julian date (in the selected timescale)
  * @param eop           (optional) Earth Orientation Parameters (EOP) values, e.g. obtained from
  *                      IERS, or EOP::undefined() to fetch it from IERS, if possible and allowed
@@ -107,6 +113,12 @@ Time::Time(long ijd, double fjd, int leap_seconds, double dUT1, enum novas_times
 /**
  * Instantiates an astrometric time instance with the specified time parameters.
  *
+ * NOTES:
+ *
+ * - If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *   configuration options), then automatic fetching of the leap seconds and the UT1 - UTC
+ *   differennce is not possible. You must set a valid EOP explicitly.
+ *
  * @param ijd           [day] integer part of Julian date (in the selected timescale)
  * @param fjd           [day] fractional part of Julian date (in the selected timescale)
  * @param eop           (optional) Earth Orientation Parameters (EOP) values, e.g. obtained from
@@ -148,6 +160,12 @@ Time::Time(const std::string& timestamp, int leap_seconds, double dUT1, enum nov
 /**
  * Instantiates an astrometric time instance with the specified time parameters.
  *
+ * NOTES:
+ *
+ * - If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *   configuration options), then automatic fetching of the leap seconds and the UT1 - UTC
+ *   differennce is not possible. You must set a valid EOP explicitly.
+ *
  * @param timestamp     A precision timestamp, such as an ISO 8601 timestamp.
  * @param eop           (optional) Earth Orientation Parameters (EOP) values, e.g. obtained from
  *                      IERS, or EOP::undefined() to fetch it from IERS, if possible and allowed
@@ -188,6 +206,12 @@ Time::Time(const struct timespec *t, int leap_seconds, double dUT1) {
 
 /**
  * Instantiates an astrometric time instance with the specified time parameters.
+ *
+ * NOTES:
+ *
+ * - If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` or `WITHOUT_LIBC` build
+ *   configuration options), then automatic fetching of the leap seconds and the UT1 - UTC
+ *   differennce is not possible. You must set a valid EOP explicitly.
  *
  * @param t             A precision POSIX standard UTC timestamp.
  * @param eop           (optional) Earth Orientation Parameters (EOP) values, e.g. obtained from
@@ -864,6 +888,13 @@ Time Time::from_mjd(double mjd, const EOP& eop, enum novas_timescale timescale) 
  * sure that your computer is well synchronized to a trustworthy time server, preferably on a local
  * network, such as an ntp server with a GPS receiver.
  *
+ * NOTES:
+ *
+ *  - If __SuperNOVAS__ was built with the `WITHOUT_SYSTEM_CLOCK` preprocessor flag (or with the
+ *    `WITHOUT_LIBC` build configuration option), then this function will always return an invalid
+ *    / undefined time (`errno` set to `ENOSYS`). You may want to set the time explicitly with one
+ *    of the constructors or other static methods instead.
+ *
  * @param leap_seconds  [s] leap seconds, that is TAI - UTC (default: 0). It may be unused if
  *                      `dUT1` is NAN -- see below.
  * @param dUT1          [s] UT1 - UTC time difference, e.g. from the IERS Bulletins or service, or
@@ -890,6 +921,16 @@ Time Time::now(int leap_seconds, double dUT1) {
  * system clock, and its precision may be limited by the resolution of the system clock also. Be
  * sure that your computer is well synchronized to a trustworthy time server, preferably on a local
  * network, such as an ntp server with a GPS receiver.
+ *
+ * NOTES:
+ *
+ *  - If __SuperNOVAS__ was built without `libc` support (`WITHOUT_LIBC` build configuration
+ *    option), then this function will always return an invalid (undefined) time (`errno` set to
+ *    `ENOSYS`).
+ *
+ *  - If __SuperNOVAS__ was built without cURL support (`WITHOUT_CURL` build configuration
+ *    option), then automatic fetching of the leap seconds and the UT1 - UTC differennce is not
+ *    possible. You must set a valid EOP explicitly.
  *
  * @param eop           (optional) Earth Orientation Parameters (EOP) values, e.g. obtained from
  *                      IERS, or EOP::undefined() to fetch it from IERS, if possible and

--- a/test/c99/CMakeLists.txt
+++ b/test/c99/CMakeLists.txt
@@ -45,7 +45,7 @@ foreach(TEST ${TEST_PROGRAMS})
         # Link against the supernovas library
         target_link_libraries(${TEST} PRIVATE core)
         
-        target_compile_definitions(${TEST} PRIVATE RESOURCES="${PROJECT_SOURCE_DIR}/resources")
+        target_compile_definitions(${TEST} PRIVATE RESOURCES="${PROJECT_SOURCE_DIR}/test/c99/resources")
         
         if(WITHOUT_CURL)
             target_compile_definitions(${TEST} PRIVATE WITHOUT_CURL=1)

--- a/test/c99/Makefile
+++ b/test/c99/Makefile
@@ -12,9 +12,6 @@ CPPFLAGS += -I../../include -I../../legacy
 CFLAGS += -pg -Wall -fprofile-arcs -ftest-coverage
 LDFLAGS += -lm -fprofile-arcs -ftest-coverage
 
-ifeq ($(CURL_SUPPORT),1)
-  LDFLAGS += -lcurl
-endif
 
 # Allow deprecated functions to be used internally
 CFLAGS += -Wno-deprecated-declarations
@@ -43,7 +40,8 @@ ifeq ($(CSPICE_SUPPORT),1)
   COVFILES += solsys-cspice.c.gcov
 endif
 
-ifeq ($(CURL_SUPPORT),1)
+ifneq ($(WITHOUT_CURL),1)
+  LDFLAGS += -lcurl
   TESTS += test-dummy-curl
 endif
 
@@ -60,7 +58,7 @@ endif
 ifeq ($(CSPICE_SUPPORT),1)
 	./test-cspice ../ephem
 endif
-ifeq ($(CURL_SUPPORT),1)
+ifneq ($(WITHOUT_CURL),1)
 	./test-dummy-curl
 endif
 

--- a/test/c99/test-errors.c
+++ b/test/c99/test-errors.c
@@ -3,6 +3,10 @@
  * @author Attila Kovacs
  */
 
+#ifdef _MSC_VER
+#  define _DEFAULT_SOURCE             ///< for struct timespec, PATH_MAX
+#endif
+
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -14,16 +18,17 @@
 #include "novas.h"
 #include "solarsystem.h"
 
-#if defined _WIN32
+#ifdef _MSC_VER
 #  include <windows.h>
 #  ifndef PATH_MAX
 #    define PATH_MAX MAX_PATH
 #  endif
+#  define realpath(rel, full)   _fullpath((full), (rel), PATH_MAX)
 #else
 #  include <limits.h>
 #endif
 
-#if defined _WIN32 || defined __CYGWIN__
+#ifdef WIN32
 #  define PATH_SEP  "\\"
 #else
 #  define PATH_SEP  "/"
@@ -2960,13 +2965,18 @@ static int test_fetch_eop() {
   // Reset EOP URLs to their defaults
   novas_reset_eop();
 
+  novas_set_auto_fetch_eop(0);
+#endif // WITH_CURL
+
   if(check("fetch_eop:set_eop_url:empty", -1, novas_set_eop_url(EOP_LEAP_LIST, 0, get_resource_url("leap-seconds.empty")))) n++;
   novas_set_leap_list(NULL);
   if(check("fetch_eop:lookup_leap:empty_leap", NOVAS_INVALID_LEAP, novas_lookup_leap(UNIX_SECONDS_0UTC_1JAN2000))) n++;
   if(check("fetch_eop:empty_leap", -1, novas_fetch_eop(NOVAS_JD_J2000, 0, &eop))) n++;
   novas_set_eop_url(EOP_LEAP_LIST, 0, NULL);
 
-#endif // WITH_CURL
+#if !WITHOUT_CURL
+  novas_set_auto_fetch_eop(1);
+#endif
 
   return n;
 }

--- a/test/c99/test-super.c
+++ b/test/c99/test-super.c
@@ -3,10 +3,9 @@
  * @author Attila Kovacs
  */
 
-#if !defined(_MSC_VER) && __STDC_VERSION__ < 201112L
-#  define _POSIX_C_SOURCE 199309L   ///< struct timespec
+#ifdef _MSC_VER
+#  define _DEFAULT_SOURCE             ///< for strcasecmp(), struct timespec, PATH_MAX
 #endif
-#define _DEFAULT_SOURCE             ///< for strcasecmp()
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -29,16 +28,17 @@ extern int strncasecmp(const char *s1, const char *s2, size_t n);
 
 #define J2000   NOVAS_JD_J2000
 
-#if defined _WIN32
+#ifdef _MSC_VER
 #  include <windows.h>
 #  ifndef PATH_MAX
 #    define PATH_MAX MAX_PATH
 #  endif
+#  define realpath(rel, full)   _fullpath((full), (rel), PATH_MAX)
 #else
 #  include <limits.h>
 #endif
 
-#if defined _WIN32 || defined __CYGWIN__
+#ifdef WIN32
 #  define PATH_SEP  "\\"
 #else
 #  define PATH_SEP  "/"
@@ -2192,7 +2192,7 @@ static int test_unix_time() {
 }
 
 static int test_set_current_time() {
-#ifdef NOVAS_NO_SYSTEM_CLOCK
+#ifdef WITHOUT_SYSTEM_CLOCK
   novas_timespec t = {};
   // With the system clock disabled, novas_set_current_time() must return -1
   // with errno set to ENOSYS, and must not touch the output.

--- a/test/cpp/Makefile
+++ b/test/cpp/Makefile
@@ -12,7 +12,7 @@ CPP_OBJECTS = $(subst .cpp,.opp, $(subst $(CPP_SRC)/,obj/, $(CPP_SOURCES)))
 
 TESTS = $(subst .cpp,, $(wildcard *.cpp))
 
-ifeq ($(CURL_SUPPORT),1)
+ifneq ($(WITHOUT_CURL),1)
   LDFLAGS += -lcurl
 endif
 


### PR DESCRIPTION
- Renamed preprocessor options to `WITHOUT_LIBC` / `WITHOUT_SYSTEM_CLOCK`
- `WITHOUT_CURL` precompiler option does not need value
- Forcing GNU make settings for `WITHOUT_LIBC` option moved to `config.mk`, with message.
- Tweaked `build.yml`
- Tweaked how `novas_snprintf()` is defined based on preprocessor options.
- Document functions / methods affected by build config
- Fix resource location in `tests/c99/CmakeLists.txt`
- Tweak feature test macros in sources (e.g. `timescale.c`)
- tests source tweaks for MSC.