### PR TITLE
Fix stack buffer overflow in novas_timestamp() / novas_iso_timestamp()

### DIFF
--- a/src/c99/timescale.c
+++ b/src/c99/timescale.c
@@ -1148,7 +1148,7 @@ double novas_date_scale(const char *restrict date, enum novas_timescale *restric
 
 static int timestamp(long ijd, double fjd, enum novas_calendar_type cal, char *buf) {
   long dd, ms;
-  int y = 0, M = 0, d = 0, h, m, s;
+  int y = 0, M = 0, d = 0, h, m, s, n;
 
   // fjd -> [-0.5:0.5) range
   dd = (long) floor(fjd + 0.5);
@@ -1175,7 +1175,11 @@ static int timestamp(long ijd, double fjd, enum novas_calendar_type cal, char *b
   s = (int) (ms / 1000L);
   ms -= 1000L * s;
 
-  return novas_snprintf(buf, NOVAS_TIMESTAMP_LEN, "%04d-%02d-%02dT%02d:%02d:%02d.%03d", y, M, d, h, m, s, (int) ms);
+  // snprintf() returns the length it _would_ have written; clamp to the number of characters
+  // actually placed in buf (at most NOVAS_TIMESTAMP_LEN - 1) so callers cannot index out of
+  // bounds when an out-of-range date produces a many-digit year.
+  n = novas_snprintf(buf, NOVAS_TIMESTAMP_LEN, "%04d-%02d-%02dT%02d:%02d:%02d.%03d", y, M, d, h, m, s, (int) ms);
+  return n < NOVAS_TIMESTAMP_LEN ? n : (NOVAS_TIMESTAMP_LEN - 1);
 }
 
 /**

--- a/test/c99/test-super.c
+++ b/test/c99/test-super.c
@@ -3815,6 +3815,17 @@ static int test_iso_timestamp() {
     }
   }
 
+  // Regression: a far out-of-range Julian Date yields a many-digit year. The
+  // formatted result must never exceed the internal 40-byte buffer; before the
+  // fix the snprintf() would-be length was used as a write index past it.
+  {
+    char big[64] = {'\0'};
+    int len;
+    if(!is_ok("iso_timestamp:oob:set_time", novas_set_time(NOVAS_UTC, 9.0e18, 0, 0.0, &time))) n++;
+    len = novas_iso_timestamp(&time, big, sizeof(big));
+    if(!is_ok("iso_timestamp:oob:bounds", len < 0 || len >= 40)) n++;
+  }
+
   return n;
 }
 
@@ -3898,6 +3909,17 @@ static int test_timestamp() {
   if(!is_ok("timestamp:round:check", strncmp("2000-01-02T", ts, 11))) {
     printf(" >>> got: %s', expected '2000-01-02'\n", ts);
     n++;
+  }
+
+  // Regression: a far out-of-range Julian Date yields a many-digit year. The
+  // formatted result must never exceed the internal 40-byte buffer; before the
+  // fix the snprintf() would-be length was used as a write index past it.
+  {
+    char big[64] = {'\0'};
+    int len;
+    if(!is_ok("timestamp:oob:set_time", novas_set_time(NOVAS_UTC, 9.0e18, 0, 0.0, &time))) n++;
+    len = novas_timestamp(&time, NOVAS_TDB, big, sizeof(big));
+    if(!is_ok("timestamp:oob:bounds", len < 0 || len >= 40)) n++;
   }
 
   return n;


### PR DESCRIPTION
## Summary

`novas_timestamp()` and `novas_iso_timestamp()` write a formatted timestamp into a
fixed 40-byte stack buffer (`char buf[40]`). The internal helper `timestamp()` builds
the string with `novas_snprintf(buf, NOVAS_TIMESTAMP_LEN, ...)` and returned the value
`snprintf()` returns — which is the number of characters that *would* have been written
for an unbounded buffer, **not** the number actually written.

For an out-of-range Julian Date the year field grows to many digits, so this return
value can exceed the buffer size. The callers then use it as a write **index** into
`buf` (`buf[l++] = 'Z';`, `buf[n++] = ' ';`, `novas_print_timescale(scale, &buf[n])`),
writing past the end of the 40-byte stack buffer. The `if (... >= maxlen)` clamps only
guard the caller's `dst`; the out-of-bounds writes to the internal buffer happen before
them. Confirmed with AddressSanitizer (out-of-bounds stack WRITE at `timescale.c:1303`).

Affects current `main` (v1.7.1); the timestamp API was introduced in v1.3, so
v1.3.0–v1.7.1 are affected.

## Fix

Clamp the helper's return value to the number of characters actually placed in `buf`
(at most `NOVAS_TIMESTAMP_LEN - 1`), so callers can never index past the buffer. This
fixes both call sites with a single change and does not alter behaviour for normal
in-range dates.

## Tests

Added regression cases to `test_timestamp()` and `test_iso_timestamp()` in
`test/c99/test-super.c` exercising a far out-of-range Julian Date. They fail on the
prior code (the formatted length exceeds the internal buffer) and pass with the fix;
`make test` is green.

Fixes #345
