### PR TITLE
More robust leap list expiration timestamp handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,14 @@ Upcoming bug-fix release, possibly around 1 August 2026.
  - #347: pkgconfig to call `find_dependency(CURL)` when __SuperNOVAS__ is built with `WITHOUT_CURL=FALSE` (by
    BillyONeal).
  
- - #350: Possible memleak in `parse_leaps()` if there is a corrupted expiration stamp in an unexpected place (by  @traitimtrongvag).
+ - #350: Possible memleak in `parse_leaps()` if there is a corrupted expiration stamp in an unexpected place (by 
+   traitimtrongvag).
  
+### Changed
+
+ - #351: Improve handling of leap exiration timestamps, but tolerating bad timestamps so long as there is a good one
+   also. Only the first valid timestamp is used.
+
 
 ## [1.7.1] - 2026-06-17
 

--- a/src/c99/iers.c
+++ b/src/c99/iers.c
@@ -232,26 +232,18 @@ static iers_leap_entry *parse_leaps(char *buf, long long *expiration) {
 
   iers_leap_entry *list = NULL;
   char *ptr = buf, *line, *context = NULL;
+  int got_expiration = 0;
 
   // Parse leap-seconds.list data
-  while((line = strtok_r(ptr, "\r\n", &context)) != NULL) if(line[0]) {
+  while((line = strtok_r(ptr, "\r\n", &context)) != NULL) {
     ptr = NULL; // Keep parsing from the same input
 
-    // Process expiration timestamp
-    if(line[0] == '#') {
-      if(line[1] == '@') {
-        if(sscanf(&line[2], "%lld", expiration) < 1) {
-          destroy_leap_list(list);
-          novas_set_errno(errno, fn, "could not parse leap-seconds.list expiration time.");
-          return NULL;
-        }
-        *expiration -= NTP_UNIX_EPOCH;
-      }
-    }
-    else {
+    if(!line[0]) continue; // Skip empty lines
+
+    if(line[0] != '#') { // Not a comment line, we expect a leap list entry...
       // Add leap entry to list
       iers_leap_entry *e = (iers_leap_entry *) calloc(1, sizeof(iers_leap_entry));
-      long long start = 0LL;
+      long long ntp_start = 0LL;
 
       // -- It's hard to produce a malloc fail in a test environment, so we'll skip coverage tracking on it.
       // LCOV_EXCL_START
@@ -263,7 +255,7 @@ static iers_leap_entry *parse_leaps(char *buf, long long *expiration) {
       // LCOV_EXCL_STOP
 
       // Parse start time and leap seconds value
-      if(sscanf(line, "%lld %d", &start, &e->leap) < 2) {
+      if(sscanf(line, "%lld %d", &ntp_start, &e->leap) < 2) {
         free(e);
         destroy_leap_list(list);
         novas_set_errno(errno, fn, "invalid leap-seconds.list entry: %s", line);
@@ -271,13 +263,26 @@ static iers_leap_entry *parse_leaps(char *buf, long long *expiration) {
       }
 
       // Prepend to head of list.
-      e->unix_start = (time_t) (start - NTP_UNIX_EPOCH);
+      e->unix_start = (time_t) (ntp_start - NTP_UNIX_EPOCH);
       e->unix_end = (time_t) *expiration;
       e->next = list;
       if(e->next)
         e->next->unix_end = e->unix_start;
       list = e;
     }
+    else if(line[1] == '@') { // Process expiration timestamp
+      // We'll use the first valid expiration timestamp (there should be only one, but...).
+      if(!got_expiration && sscanf(&line[2], "%lld", expiration) == 1) {
+        *expiration -= NTP_UNIX_EPOCH;
+        got_expiration = 1;
+      }
+    }
+  } // while loop over lines.
+
+  if(!got_expiration) {
+    destroy_leap_list(list);
+    novas_set_errno(errno, fn, "could not parse leap-seconds.list expiration time.");
+    return NULL;
   }
 
   return list;

--- a/test/c99/resources/bad-expiration-ok1.list
+++ b/test/c99/resources/bad-expiration-ok1.list
@@ -1,0 +1,49 @@
+# >> We have a proper expiration timestamp, as expected
+#@	4007404800
+#
+# >> So, we can safely ignore bad expiration stamps afterwards
+#@	X4007404800
+#
+#
+#	LIST OF LEAP SECONDS
+#	NTP timestamp (X parameter) is the number of seconds since 1900.0
+#
+#	MJD: The Modified Julian Day number. MJD = X/86400 + 15020
+#
+#	DTAI: The difference DTAI= TAI-UTC in units of seconds
+#	It is the quantity to add to UTC to get the time in TAI
+#
+#	Day Month Year : epoch in clear
+#
+#NTP Time      DTAI    Day Month Year
+#
+2272060800      10      # 1 Jan 1972
+2287785600      11      # 1 Jul 1972
+2303683200      12      # 1 Jan 1973
+2335219200      13      # 1 Jan 1974
+2366755200      14      # 1 Jan 1975
+2398291200      15      # 1 Jan 1976
+2429913600      16      # 1 Jan 1977
+2461449600      17      # 1 Jan 1978
+2492985600      18      # 1 Jan 1979
+2524521600      19      # 1 Jan 1980
+2571782400      20      # 1 Jul 1981
+2603318400      21      # 1 Jul 1982
+2634854400      22      # 1 Jul 1983
+2698012800      23      # 1 Jul 1985
+2776982400      24      # 1 Jan 1988
+2840140800      25      # 1 Jan 1990
+2871676800      26      # 1 Jan 1991
+2918937600      27      # 1 Jul 1992
+2950473600      28      # 1 Jul 1993
+2982009600      29      # 1 Jul 1994
+3029443200      30      # 1 Jan 1996
+3076704000      31      # 1 Jul 1997
+3124137600      32      # 1 Jan 1999
+3345062400      33      # 1 Jan 2006
+3439756800      34      # 1 Jan 2009
+3550089600      35      # 1 Jul 2012
+3644697600      36      # 1 Jul 2015
+3692217600      37      # 1 Jan 2017
+#
+

--- a/test/c99/resources/bad-expiration-ok2.list
+++ b/test/c99/resources/bad-expiration-ok2.list
@@ -1,0 +1,51 @@
+# >> We may have a bad expiration timestamp, but that is OK, so long as we
+# >> also get a valid one later...
+#@	X4007404800
+#
+# >> We now have a proper expiration timestamp, so we should be OK
+#@	4007404800
+#
+#
+#
+#	LIST OF LEAP SECONDS
+#	NTP timestamp (X parameter) is the number of seconds since 1900.0
+#
+#	MJD: The Modified Julian Day number. MJD = X/86400 + 15020
+#
+#	DTAI: The difference DTAI= TAI-UTC in units of seconds
+#	It is the quantity to add to UTC to get the time in TAI
+#
+#	Day Month Year : epoch in clear
+#
+#NTP Time      DTAI    Day Month Year
+#
+2272060800      10      # 1 Jan 1972
+2287785600      11      # 1 Jul 1972
+2303683200      12      # 1 Jan 1973
+2335219200      13      # 1 Jan 1974
+2366755200      14      # 1 Jan 1975
+2398291200      15      # 1 Jan 1976
+2429913600      16      # 1 Jan 1977
+2461449600      17      # 1 Jan 1978
+2492985600      18      # 1 Jan 1979
+2524521600      19      # 1 Jan 1980
+2571782400      20      # 1 Jul 1981
+2603318400      21      # 1 Jul 1982
+2634854400      22      # 1 Jul 1983
+2698012800      23      # 1 Jul 1985
+2776982400      24      # 1 Jan 1988
+2840140800      25      # 1 Jan 1990
+2871676800      26      # 1 Jan 1991
+2918937600      27      # 1 Jul 1992
+2950473600      28      # 1 Jul 1993
+2982009600      29      # 1 Jul 1994
+3029443200      30      # 1 Jan 1996
+3076704000      31      # 1 Jul 1997
+3124137600      32      # 1 Jan 1999
+3345062400      33      # 1 Jan 2006
+3439756800      34      # 1 Jan 2009
+3550089600      35      # 1 Jul 2012
+3644697600      36      # 1 Jul 2015
+3692217600      37      # 1 Jan 2017
+#
+

--- a/test/c99/test-super.c
+++ b/test/c99/test-super.c
@@ -5947,6 +5947,16 @@ static int test_lookup_leap() {
     if(!is_equal("lookup_leap:offline:j2000", novas_lookup_leap(946684800L), 32.0, 1e-15)) n++;
   }
 
+  rc = get_resource("bad-expiration-ok1.list", path, sizeof(path));
+  if(!rc) fprintf(stderr, "WARNING! Missing %s: skip tests requiring it", path);
+  else if(!is_ok("lookup_leap:set_leap_list:bad-first-expiration", novas_set_leap_list(path))) return ++n;
+
+  rc = get_resource("bad-expiration-ok2.list", path, sizeof(path));
+  if(!rc) fprintf(stderr, "WARNING! Missing %s: skip tests requiring it", path);
+  else if(!is_ok("lookup_leap:set_leap_list:bad-second-expiration", novas_set_leap_list(path))) return ++n;
+
+  novas_set_leap_list(NULL);
+
   return n;
 }
 


### PR DESCRIPTION
- Tolerate bad expiration timestamps, so long as there is a valid one.
-  If multiple timestamps appear, the first one will be used.
- Parse efficiency when file begins with empty lines (`strtok_r()` was still called with the buffer pointer)