### PR TITLE
Fix WITHOUT_CURL=1 test build failing on missing curl.h

### DIFF
--- a/test/c99/Makefile
+++ b/test/c99/Makefile
@@ -40,7 +40,9 @@ ifeq ($(CSPICE_SUPPORT),1)
   COVFILES += solsys-cspice.c.gcov
 endif
 
-ifneq ($(WITHOUT_CURL),1)
+ifeq ($(WITHOUT_CURL),1)
+  CPPFLAGS += -DWITHOUT_CURL
+else
   LDFLAGS += -lcurl
   TESTS += test-dummy-curl
 endif


### PR DESCRIPTION
## Build

### Fixed

- I found that building the regression tests with `WITHOUT_CURL=1` failed because `WITHOUT_CURL` was not propagated to the preprocessor.
- I updated `test/c99/Makefile` to define `WITHOUT_CURL` when the flag is enabled.